### PR TITLE
removed multi transporter logic. consumers can compose their own

### DIFF
--- a/span_implementation.go
+++ b/span_implementation.go
@@ -41,26 +41,20 @@ func (s *spanImpl) Tag(key, value string) {
 func (s *spanImpl) Finish() {
 	s.Duration = time.Since(s.Timestamp)
 	if s.isSampled {
-		for _, t := range s.tracer.options.transporters {
-			t.Send(s.SpanModel)
-		}
+		s.tracer.options.transport.Send(s.SpanModel)
 	}
 }
 
 func (s *spanImpl) FinishWithTime(t time.Time) {
 	s.Duration = t.Sub(s.Timestamp)
 	if s.isSampled {
-		for _, t := range s.tracer.options.transporters {
-			t.Send(s.SpanModel)
-		}
+		s.tracer.options.transport.Send(s.SpanModel)
 	}
 }
 
 func (s *spanImpl) FinishWithDuration(d time.Duration) {
 	s.Duration = d
 	if s.isSampled {
-		for _, t := range s.tracer.options.transporters {
-			t.Send(s.SpanModel)
-		}
+		s.tracer.options.transport.Send(s.SpanModel)
 	}
 }

--- a/tracer.go
+++ b/tracer.go
@@ -19,6 +19,7 @@ func NewTracer(options ...TracerOption) (*Tracer, error) {
 		sampler:     alwaysSample,
 		generate:    &RandomID64{},
 		defaultTags: make(map[string]string),
+		transport:   &NoopTransport{},
 	}
 
 	// process functional options

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -30,7 +30,7 @@ type TracerOptions struct {
 	defaultTags          map[string]string
 	unsampledNoop        bool
 	extractFailurePolicy ExtractFailurePolicy
-	transporters         []Transporter
+	transport            Transporter
 }
 
 // WithLocalEndpoint sets the local endpoint of the tracer.
@@ -102,9 +102,9 @@ func WithTags(tags map[string]string) TracerOption {
 }
 
 // WithTransporters sets the transporters to deliver spans to.
-func WithTransporters(t ...Transporter) TracerOption {
+func WithTransporters(t Transporter) TracerOption {
 	return func(o *TracerOptions) error {
-		o.transporters = t
+		o.transport = t
 		return nil
 	}
 }


### PR DESCRIPTION
No need to handle this at library level. consumers can compose their own multi transport and implement Transporter interface.