### PR TITLE
improved Tag behavior and added tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Travis CI](https://travis-ci.org/openzipkin/zipkin-go.svg?branch=master)](https://travis-ci.org/openzipkin/zipkin-go)
 [![CircleCI](https://circleci.com/gh/openzipkin/zipkin-go.svg?style=shield)](https://circleci.com/gh/openzipkin/zipkin-go)
+[![Coverage Status](https://coveralls.io/repos/github/openzipkin/zipkin-go/badge.svg?branch=master&service=github)](https://coveralls.io/github/openzipkin/zipkin-go?branch=master)
 [![GoDoc](https://godoc.org/github.com/openzipkin/zipkin-go?status.svg)](https://godoc.org/github.com/openzipkin/zipkin-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/openzipkin/zipkin-go)](https://goreportcard.com/report/github.com/openzipkin/zipkin-go)
 [![Sourcegraph](https://sourcegraph.com/github.com/openzipkin/zipkin-go/-/badge.svg)](https://sourcegraph.com/github.com/openzipkin/zipkin-go?badge)
-[![Coverage Status](https://coveralls.io/repos/github/openzipkin/zipkin-go/badge.svg?branch=master&service=github)](https://coveralls.io/github/openzipkin/zipkin-go?branch=master)
 
 Zipkin tracer library for go
 

--- a/middleware/http_handler_test.go
+++ b/middleware/http_handler_test.go
@@ -1,0 +1,124 @@
+package middleware_test
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+
+	zipkin "github.com/openzipkin/zipkin-go"
+	"github.com/openzipkin/zipkin-go/middleware"
+	"github.com/openzipkin/zipkin-go/model"
+)
+
+var (
+	lep, _ = zipkin.NewEndpoint("testSvc", "127.0.0.1:0")
+)
+
+type reporterRecorder struct {
+	mtx   sync.Mutex
+	spans []model.SpanModel
+}
+
+func (r *reporterRecorder) Send(span model.SpanModel) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	r.spans = append(r.spans, span)
+}
+
+func (r *reporterRecorder) Flush() []model.SpanModel {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	spans := r.spans
+	r.spans = nil
+	return spans
+}
+
+func (r *reporterRecorder) Close() error {
+	_ = r.Flush
+	return nil
+}
+
+func httpHandler(code int, headers http.Header, body *bytes.Buffer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+		for key, value := range headers {
+			log.Println(key, value)
+			w.Header().Add(key, value[0])
+		}
+		w.Write(body.Bytes())
+	}
+}
+
+func TestHTTPHandlerWrapping(t *testing.T) {
+	var (
+		spanRecorder = &reporterRecorder{}
+		tr, _        = zipkin.NewTracer(spanRecorder, zipkin.WithLocalEndpoint(lep))
+		httpRecorder = httptest.NewRecorder()
+		requestBuf   = bytes.NewBuffer([]byte("incoming data"))
+		responseBuf  = bytes.NewBuffer([]byte("oh oh we have a 404"))
+		headers      = make(http.Header)
+		code         = 404
+	)
+	headers.Add("some-key", "some-value")
+	headers.Add("other-key", "other-value")
+
+	request, err := http.NewRequest("POST", "/test", requestBuf)
+	if err != nil {
+		t.Fatalf("unable to create request")
+	}
+
+	httpHandlerFunc := http.HandlerFunc(httpHandler(code, headers, responseBuf))
+
+	handler := middleware.WrapHTTPHandler(tr, "wrapper_test", httpHandlerFunc)
+
+	handler.ServeHTTP(httpRecorder, request)
+
+	spans := spanRecorder.Flush()
+
+	if want, have := 1, len(spans); want != have {
+		t.Errorf("Expected %d spans, got %d", want, have)
+	}
+
+	span := spans[0]
+
+	if want, have := strconv.Itoa(requestBuf.Len()), span.Tags["http.request.size"]; want != have {
+		t.Errorf("Expected span request size %s, got %s", want, have)
+	}
+
+	if want, have := strconv.Itoa(responseBuf.Len()), span.Tags["http.response.size"]; want != have {
+		t.Errorf("Expected span response size %s, got %s", want, have)
+
+	}
+
+	if want, have := strconv.Itoa(code), span.Tags["http.status_code"]; want != have {
+		t.Errorf("Expected span status code %s, got %s", want, have)
+	}
+
+	if want, have := strconv.Itoa(code), span.Tags["error"]; want != have {
+		t.Errorf("Expected span error %q, got %q", want, have)
+	}
+
+	if want, have := len(headers), len(httpRecorder.HeaderMap); want != have {
+		t.Errorf("Expected http header count %d, got %d", want, have)
+	}
+
+	if want, have := code, httpRecorder.Code; want != have {
+		t.Errorf("Expected http status code %s, got %s", want, have)
+	}
+
+	for key, value := range headers {
+		if want, have := value, httpRecorder.HeaderMap.Get(key); want[0] != have {
+			t.Errorf("Expected header %s value %s, got %s", key, want, have)
+		}
+	}
+
+	if want, have := responseBuf.String(), httpRecorder.Body.String(); want != have {
+		t.Errorf("Expected body value %q, got %q", want, have)
+	}
+}

--- a/middleware/http_handler_test.go
+++ b/middleware/http_handler_test.go
@@ -109,7 +109,7 @@ func TestHTTPHandlerWrapping(t *testing.T) {
 	}
 
 	if want, have := code, httpRecorder.Code; want != have {
-		t.Errorf("Expected http status code %s, got %s", want, have)
+		t.Errorf("Expected http status code %d, got %d", want, have)
 	}
 
 	for key, value := range headers {

--- a/sample_test.go
+++ b/sample_test.go
@@ -50,3 +50,26 @@ func TestCountingSampler(t *testing.T) {
 		}
 	}
 }
+
+func TestModuleSampler(t *testing.T) {
+	const (
+		max = 1000
+		mod = 25
+	)
+
+	var (
+		sampler = zipkin.NewModuloSampler(mod)
+		found   = 0
+	)
+
+	for i := uint64(0); i < max; i++ {
+		if sampler(i) {
+			found++
+		}
+	}
+
+	if want, have := max/mod, found; want != have {
+		t.Errorf("expected %d samples, got %d", want, have)
+	}
+
+}

--- a/span_implementation.go
+++ b/span_implementation.go
@@ -33,10 +33,17 @@ func (s *spanImpl) Annotate(t time.Time, value string) {
 }
 
 // Tag sets Tag with given key and value to the Span. If key already exists in
-// the span the value will be overridden.
+// the span the value will be overridden except for error tags where the first
+// value is persisted.
 func (s *spanImpl) Tag(key, value string) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
+	if key == string(TagError) {
+		if _, found := s.Tags[key]; found {
+			return
+		}
+	}
 
 	s.Tags[key] = value
 }


### PR DESCRIPTION
Tags in V2 model typically overwrite on key collission. This is fine except for "error" payloads where typically the first error is more important then the next (often just cascading).

This also helps allowing a server span to auto tag a statuscode > 399 as error except if an error tag already exists (most likely the source).

Also added more unit tests for previously untested items