### PR TITLE
improved duration and timestamp logic

### DIFF
--- a/model/span.go
+++ b/model/span.go
@@ -64,8 +64,13 @@ func (s SpanModel) MarshalJSON() ([]byte, error) {
 			s.Duration = 1 * time.Microsecond
 		}
 	} else {
-		// duration is rounded to nearest microsecond representation
-		s.Duration = s.Duration.Round(time.Microsecond)
+		// Duration will be rounded to nearest microsecond representation.
+		//
+		// NOTE: Duration.Round() is not available in Go 1.8 which we still support.
+		// To handle microsecond resolution rounding we'll add 500 nanoseconds to
+		// the duration. When truncated to microseconds in the call to marshal, it
+		// will be naturally rounded. See TestSpanDurationRounding in span_test.go
+		s.Duration += 500 * time.Nanosecond
 	}
 
 	return json.Marshal(&struct {

--- a/reporter/http/http_test.go
+++ b/reporter/http/http_test.go
@@ -36,7 +36,17 @@ func TestSpanIsBeingReported(t *testing.T) {
 		}
 
 		aSpans = append(aSpans, span)
-		eSpans = append(eSpans, fmt.Sprintf(expectedSpanTpl, span.Timestamp.Round(time.Microsecond).UnixNano()/1e3, span.SpanContext.TraceID.ToHex(), fmt.Sprintf("%16x", span.SpanContext.ID), span.Name, span.Kind))
+		eSpans = append(
+			eSpans,
+			fmt.Sprintf(
+				`{"timestamp":%d,"traceId":"%s","id":"%s","name":"%s","kind":"%s"}`,
+				span.Timestamp.Round(time.Microsecond).UnixNano()/1e3,
+				span.SpanContext.TraceID.ToHex(),
+				fmt.Sprintf("%016x", span.SpanContext.ID),
+				span.Name,
+				span.Kind,
+			),
+		)
 	}
 
 	eSpansPayload := fmt.Sprintf("[%s]", strings.Join(eSpans, ","))
@@ -65,5 +75,3 @@ func TestSpanIsBeingReported(t *testing.T) {
 		rep.Send(span)
 	}
 }
-
-const expectedSpanTpl = `{"timestamp":%d,"traceId":"%s","id":"%s","name":"%s","kind":"%s"}`


### PR DESCRIPTION
- Timestamps before unix epoch will not be allowed
- Durations between 1 and 999 nanoseconds will be rounded up to 1 microsecond
- Durations above 1 microsecond will be naturally rounded to microsecond resolution, not truncated