### PR TITLE
improved endpoint handling allowing empty hostPort if unknown

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -15,6 +15,10 @@ func NewEndpoint(serviceName string, hostPort string) (*model.Endpoint, error) {
 		ServiceName: serviceName,
 	}
 
+	if hostPort == "" {
+		return e, nil
+	}
+
 	if strings.IndexByte(hostPort, ':') < 0 {
 		hostPort += ":0"
 	}

--- a/endpoint.go
+++ b/endpoint.go
@@ -15,7 +15,11 @@ func NewEndpoint(serviceName string, hostPort string) (*model.Endpoint, error) {
 		ServiceName: serviceName,
 	}
 
-	if hostPort == "" {
+	if hostPort == "" || hostPort == ":0" {
+		if serviceName == "" {
+			// if all properties are empty we should not have an Endpoint object.
+			return nil, nil
+		}
 		return e, nil
 	}
 

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -34,8 +34,8 @@ func TestEmptyEndpoint(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
-	if want, have := &(model.Endpoint{}), ep; !reflect.DeepEqual(want, have) {
-		t.Errorf("endpoint want %+v, have: %+v", want, have)
+	if ep != nil {
+		t.Errorf("endpoint want nil, have: %+v", ep)
 	}
 }
 

--- a/middleware/doc.go
+++ b/middleware/doc.go
@@ -1,5 +1,5 @@
 /*
-Package middleware contains several middlewares which be used for instrumenting
-calls with zipkin.
+Package middleware contains several middlewares which can be used for
+instrumenting calls with Zipkin.
 */
 package middleware

--- a/model/endpoint.go
+++ b/model/endpoint.go
@@ -9,3 +9,9 @@ type Endpoint struct {
 	IPv6        net.IP `json:"ipv6,omitempty"`
 	Port        uint16 `json:"port,omitempty"`
 }
+
+// Empty returns if all Endpoint properties are empty / unspecified.
+func (e *Endpoint) Empty() bool {
+	return e == nil ||
+		(e.ServiceName == "" && e.Port == 0 && len(e.IPv4) == 0 && len(e.IPv6) == 0)
+}

--- a/model/endpoint_test.go
+++ b/model/endpoint_test.go
@@ -1,0 +1,38 @@
+package model_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/openzipkin/zipkin-go/model"
+)
+
+func TestEmptyEndpoint(t *testing.T) {
+	var e *model.Endpoint
+
+	if want, have := true, e.Empty(); want != have {
+		t.Errorf("Endpoint want %t, have %t", want, have)
+	}
+
+	e = &model.Endpoint{}
+
+	if want, have := true, e.Empty(); want != have {
+		t.Errorf("Endpoint want %t, have %t", want, have)
+	}
+
+	e = &model.Endpoint{
+		IPv4: net.IPv4zero,
+	}
+
+	if want, have := false, e.Empty(); want != have {
+		t.Errorf("Endpoint want %t, have %t", want, have)
+	}
+
+	e = &model.Endpoint{
+		IPv6: net.IPv6zero,
+	}
+
+	if want, have := false, e.Empty(); want != have {
+		t.Errorf("Endpoint want %t, have %t", want, have)
+	}
+}

--- a/model/span.go
+++ b/model/span.go
@@ -73,6 +73,14 @@ func (s SpanModel) MarshalJSON() ([]byte, error) {
 		s.Duration += 500 * time.Nanosecond
 	}
 
+	if s.LocalEndpoint.Empty() {
+		s.LocalEndpoint = nil
+	}
+
+	if s.RemoteEndpoint.Empty() {
+		s.RemoteEndpoint = nil
+	}
+
 	return json.Marshal(&struct {
 		Timestamp int64 `json:"timestamp,omitempty"`
 		Duration  int64 `json:"duration,omitempty"`
@@ -105,5 +113,12 @@ func (s *SpanModel) UnmarshalJSON(b []byte) error {
 		s.Timestamp = time.Unix(0, int64(span.TimeStamp)*1e3)
 	}
 	s.Duration = time.Duration(span.Duration*1e3) * time.Nanosecond
+	if s.LocalEndpoint.Empty() {
+		s.LocalEndpoint = nil
+	}
+
+	if s.RemoteEndpoint.Empty() {
+		s.RemoteEndpoint = nil
+	}
 	return nil
 }

--- a/model/span_id.go
+++ b/model/span_id.go
@@ -8,9 +8,14 @@ import (
 // ID type
 type ID uint64
 
+// String outputs the 64-bit ID as hex string.
+func (i ID) String() string {
+	return fmt.Sprintf("%016s", strconv.FormatUint(uint64(i), 16))
+}
+
 // MarshalJSON serializes an ID type (SpanID, ParentSpanID) to HEX.
 func (i ID) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%016s"`, strconv.FormatUint(uint64(i), 16))), nil
+	return []byte(fmt.Sprintf("%q", i.String())), nil
 }
 
 // UnmarshalJSON deserializes an ID type (SpanID, ParentSpanID) from HEX.

--- a/model/span_id.go
+++ b/model/span_id.go
@@ -10,7 +10,7 @@ type ID uint64
 
 // String outputs the 64-bit ID as hex string.
 func (i ID) String() string {
-	return fmt.Sprintf("%016s", strconv.FormatUint(uint64(i), 16))
+	return fmt.Sprintf("%016x", uint64(i))
 }
 
 // MarshalJSON serializes an ID type (SpanID, ParentSpanID) to HEX.

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -43,7 +43,7 @@ func TestSpanJSON(t *testing.T) {
 			IPv4:        net.IPv4(127, 0, 0, 1),
 			IPv6:        net.IPv6loopback,
 		},
-		RemoteEndpoint: &Endpoint{},
+		RemoteEndpoint: nil,
 		Annotations: []Annotation{
 			{time.Now().Add(-90 * time.Millisecond), "myAnnotation"},
 		},

--- a/model/traceid.go
+++ b/model/traceid.go
@@ -12,6 +12,21 @@ type TraceID struct {
 	Low  uint64
 }
 
+// Empty returns if TraceID has zero value.
+func (t TraceID) Empty() bool {
+	return t.Low == 0 && t.High == 0
+}
+
+// String outputs the 128-bit traceID as hex string.
+func (t TraceID) String() string {
+	if t.High == 0 {
+		return fmt.Sprintf("%016s", strconv.FormatUint(t.Low, 16))
+	}
+	return fmt.Sprintf(
+		"%016s%016s", strconv.FormatUint(t.High, 16), strconv.FormatUint(t.Low, 16),
+	)
+}
+
 // TraceIDFromHex returns the TraceID from a hex string.
 func TraceIDFromHex(h string) (t TraceID, err error) {
 	if len(h) > 16 {
@@ -25,19 +40,10 @@ func TraceIDFromHex(h string) (t TraceID, err error) {
 	return
 }
 
-// ToHex outputs the 128-bit traceID as hex string.
-func (t TraceID) ToHex() string {
-	if t.High == 0 {
-		return fmt.Sprintf("%016s", strconv.FormatUint(t.Low, 16))
-	}
-	return fmt.Sprintf(
-		"%016s%016s", strconv.FormatUint(t.High, 16), strconv.FormatUint(t.Low, 16),
-	)
-}
-
-// Empty returns if TraceID has zero value.
-func (t TraceID) Empty() bool {
-	return t.Low == 0 && t.High == 0
+// MarshalJSON custom JSON serializer to export the TraceID in the required
+// zero padded hex representation.
+func (t TraceID) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%q", t.String())), nil
 }
 
 // UnmarshalJSON custom JSON deserializer to retrieve the traceID from the hex
@@ -52,10 +58,4 @@ func (t *TraceID) UnmarshalJSON(traceID []byte) error {
 	}
 	*t = tID
 	return nil
-}
-
-// MarshalJSON custom JSON serializer to export the TraceID in the required
-// zero padded hex representation.
-func (t TraceID) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("%q", t.ToHex())), nil
 }

--- a/model/traceid.go
+++ b/model/traceid.go
@@ -20,10 +20,10 @@ func (t TraceID) Empty() bool {
 // String outputs the 128-bit traceID as hex string.
 func (t TraceID) String() string {
 	if t.High == 0 {
-		return fmt.Sprintf("%016s", strconv.FormatUint(t.Low, 16))
+		return fmt.Sprintf("%016x", t.Low)
 	}
 	return fmt.Sprintf(
-		"%016s%016s", strconv.FormatUint(t.High, 16), strconv.FormatUint(t.Low, 16),
+		"%016x%016x", t.High, t.Low,
 	)
 }
 

--- a/model/traceid_test.go
+++ b/model/traceid_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestTraceID(t *testing.T) {
 	traceID := TraceID{High: 1, Low: 2}
-	if len(traceID.ToHex()) != 32 {
+	if len(traceID.String()) != 32 {
 		t.Errorf("Expected zero-padded TraceID to have 32 characters")
 	}
 
@@ -21,7 +21,7 @@ func TestTraceID(t *testing.T) {
 		t.Fatalf("Expected successful json deserialization, got error: %+v", err)
 	}
 
-	have, err := TraceIDFromHex(traceID.ToHex())
+	have, err := TraceIDFromHex(traceID.String())
 	if err != nil {
 		t.Fatalf("Expected traceID got error: %+v", err)
 	}
@@ -31,11 +31,11 @@ func TestTraceID(t *testing.T) {
 
 	traceID = TraceID{High: 0, Low: 2}
 
-	if len(traceID.ToHex()) != 16 {
-		t.Errorf("Expected zero-padded TraceID to have 16 characters, got %d", len(traceID.ToHex()))
+	if len(traceID.String()) != 16 {
+		t.Errorf("Expected zero-padded TraceID to have 16 characters, got %d", len(traceID.String()))
 	}
 
-	have, err = TraceIDFromHex(traceID.ToHex())
+	have, err = TraceIDFromHex(traceID.String())
 	if err != nil {
 		t.Fatalf("Expected traceID got error: %+v", err)
 	}

--- a/noop_test.go
+++ b/noop_test.go
@@ -1,0 +1,49 @@
+package zipkin
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/openzipkin/zipkin-go/model"
+	"github.com/openzipkin/zipkin-go/reporter/recorder"
+)
+
+func TestNoopContext(t *testing.T) {
+	var (
+		span     Span
+		sc       model.SpanContext
+		rec      = recorder.NewReporter()
+		parentID = model.ID(3)
+		tr, _    = NewTracer(
+			rec,
+			WithNoopSpan(true),
+			WithSampler(neverSample),
+			WithSharedSpans(true),
+		)
+	)
+	defer rec.Close()
+
+	sc = model.SpanContext{
+		TraceID:  model.TraceID{High: 1, Low: 2},
+		ID:       model.ID(4),
+		ParentID: &parentID,
+		Debug:    false,     // debug must be false
+		Sampled:  new(bool), // bool must be pointer to false
+	}
+
+	span = tr.StartSpan("testNoop", Parent(sc), Kind(model.Server))
+
+	noop, ok := span.(*noopSpan)
+	if !ok {
+		t.Fatalf("Span type want %s, have %s", reflect.TypeOf(&spanImpl{}), reflect.TypeOf(span))
+	}
+
+	if have := noop.Context(); !reflect.DeepEqual(sc, have) {
+		t.Errorf("Context want %+v, have %+v", sc, have)
+	}
+
+	span.Tag("dummy", "dummy")
+	span.Annotate(time.Now(), "dummy")
+	span.SetRemoteEndpoint(nil)
+}

--- a/propagation/b3/grpc.go
+++ b/propagation/b3/grpc.go
@@ -1,8 +1,6 @@
 package b3
 
 import (
-	"fmt"
-
 	"google.golang.org/grpc/metadata"
 
 	"github.com/openzipkin/zipkin-go/model"
@@ -49,10 +47,10 @@ func InjectGRPC(md *metadata.MD) propagation.Injector {
 
 		if !sc.TraceID.Empty() && sc.ID > 0 {
 			// set identifiers
-			setGRPCHeader(md, TraceID, sc.TraceID.ToHex())
-			setGRPCHeader(md, SpanID, fmt.Sprintf("%016x", sc.ID))
+			setGRPCHeader(md, TraceID, sc.TraceID.String())
+			setGRPCHeader(md, SpanID, sc.ID.String())
 			if sc.ParentID != nil {
-				setGRPCHeader(md, ParentSpanID, fmt.Sprintf("%016x", *sc.ParentID))
+				setGRPCHeader(md, ParentSpanID, sc.ParentID.String())
 			}
 		}
 

--- a/propagation/b3/http.go
+++ b/propagation/b3/http.go
@@ -1,7 +1,6 @@
 package b3
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/openzipkin/zipkin-go/model"
@@ -47,10 +46,10 @@ func InjectHTTP(r *http.Request) propagation.Injector {
 		}
 
 		if !sc.TraceID.Empty() && sc.ID > 0 {
-			r.Header.Set(TraceID, sc.TraceID.ToHex())
-			r.Header.Set(SpanID, fmt.Sprintf("%016x", sc.ID))
+			r.Header.Set(TraceID, sc.TraceID.String())
+			r.Header.Set(SpanID, sc.ID.String())
 			if sc.ParentID != nil {
-				r.Header.Set(ParentSpanID, fmt.Sprintf("%016x", *sc.ParentID))
+				r.Header.Set(ParentSpanID, sc.ParentID.String())
 			}
 		}
 

--- a/reporter/http/http_test.go
+++ b/reporter/http/http_test.go
@@ -41,8 +41,8 @@ func TestSpanIsBeingReported(t *testing.T) {
 			fmt.Sprintf(
 				`{"timestamp":%d,"traceId":"%s","id":"%s","name":"%s","kind":"%s"}`,
 				span.Timestamp.Round(time.Microsecond).UnixNano()/1e3,
-				span.SpanContext.TraceID.ToHex(),
-				fmt.Sprintf("%016x", span.SpanContext.ID),
+				span.SpanContext.TraceID,
+				span.SpanContext.ID,
 				span.Name,
 				span.Kind,
 			),

--- a/tracer.go
+++ b/tracer.go
@@ -33,7 +33,7 @@ func NewTracer(reporter reporter.Reporter, options ...TracerOption) (*Tracer, er
 		sampler:              alwaysSample,
 		generate:             idgenerator.NewRandom64(),
 		reporter:             reporter,
-		localEndpoint:        &model.Endpoint{},
+		localEndpoint:        nil,
 		noop:                 0,
 		sharedSpans:          true,
 		unsampledNoop:        false,
@@ -152,6 +152,9 @@ func (t *Tracer) SetNoop(noop bool) {
 // LocalEndpoint returns a copy of the currently set local endpoint of the
 // tracer instance.
 func (t *Tracer) LocalEndpoint() *model.Endpoint {
+	if t.localEndpoint == nil {
+		return nil
+	}
 	ep := *t.localEndpoint
 	return &ep
 }

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -31,10 +31,11 @@ type TracerOption func(o *Tracer) error
 func WithLocalEndpoint(e *model.Endpoint) TracerOption {
 	return func(o *Tracer) error {
 		if e == nil {
-			o.localEndpoint = &model.Endpoint{}
+			o.localEndpoint = nil
 			return nil
 		}
-		*o.localEndpoint = *e
+		ep := *e
+		o.localEndpoint = &ep
 		return nil
 	}
 }

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -31,7 +31,8 @@ type TracerOption func(o *Tracer) error
 func WithLocalEndpoint(e *model.Endpoint) TracerOption {
 	return func(o *Tracer) error {
 		if e == nil {
-			return ErrInvalidEndpoint
+			o.localEndpoint = &model.Endpoint{}
+			return nil
 		}
 		*o.localEndpoint = *e
 		return nil

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -13,20 +13,29 @@ import (
 )
 
 func TestTracerOptionLocalEndpoint(t *testing.T) {
+	var (
+		err    error
+		wantEP = &model.Endpoint{}
+	)
+
 	rec := recorder.NewReporter()
 	defer rec.Close()
 
 	tr, err := NewTracer(rec, WithLocalEndpoint(nil))
 
-	if want, have := ErrInvalidEndpoint, err; want != have {
-		t.Errorf("expected tracer creation failure: want %+v, have: %+v", want, have)
+	if err != nil {
+		t.Fatalf("unexpected tracer creation failure: %+v", err.Error())
 	}
 
-	if tr != nil {
-		t.Errorf("expected tracer to be nil got: %+v", tr)
+	if tr == nil {
+		t.Error("expected valid tracer, got: nil")
 	}
 
-	wantEP, err := NewEndpoint("testService", "localhost:80")
+	if want, have := wantEP, tr.LocalEndpoint(); !reflect.DeepEqual(want, have) {
+		t.Errorf("local Endpoint want %+v, have %+v", want, have)
+	}
+
+	wantEP, err = NewEndpoint("testService", "localhost:80")
 
 	if err != nil {
 		t.Fatalf("expected valid endpoint, got error: %+v", err)
@@ -707,18 +716,13 @@ func TestLocalEndpoint(t *testing.T) {
 	rec := recorder.NewReporter()
 	defer rec.Close()
 
-	tracer, err := NewTracer(rec)
-	if err != nil {
-		t.Fatalf("expected valid tracer, got error: %+v", err)
-	}
-
 	ep, err := NewEndpoint("my service", "localhost:80")
 
 	if err != nil {
 		t.Fatalf("expected valid endpoint, got error: %+v", err)
 	}
 
-	tracer, err = NewTracer(rec, WithLocalEndpoint(ep))
+	tracer, err := NewTracer(rec, WithLocalEndpoint(ep))
 	if err != nil {
 		t.Fatalf("expected valid tracer, got error: %+v", err)
 	}


### PR DESCRIPTION
Endpoints can end up being empty. we didn't properly handle NewEndpoint with empty hostPort in case host/port is unknown.