### PR TITLE
Adds Flush Method; DelaySend and Tags SpanOptions

### DIFF
--- a/noop.go
+++ b/noop.go
@@ -21,3 +21,5 @@ func (*noopSpan) Annotate(time.Time, string) {}
 func (*noopSpan) Tag(string, string) {}
 
 func (*noopSpan) Finish() {}
+
+func (*noopSpan) Flush() {}

--- a/noop_test.go
+++ b/noop_test.go
@@ -47,4 +47,5 @@ func TestNoopContext(t *testing.T) {
 	span.Annotate(time.Now(), "dummy")
 	span.SetName("dummy")
 	span.SetRemoteEndpoint(nil)
+	span.Flush()
 }

--- a/span.go
+++ b/span.go
@@ -26,12 +26,13 @@ type Span interface {
 	Tag(string, string)
 
 	// Finish the Span and send to Reporter. If DelaySend option was used at
-	// span creation time, Finish will not send the span to the reporter. It then
-	// becomes the user's responsibility to get the span reporter (by using Flush)
+	// Span creation time, Finish will not send the Span to the Reporter. It then
+	// becomes the user's responsibility to get the Span reported (by using
+	// span.Flush).
 	Finish()
 
-	// Flush the Span to the Reporter (regardless of being finished or not)
+	// Flush the Span to the Reporter (regardless of being finished or not).
 	// This can be used if the DelaySend SpanOption was set or when dealing with
-	// One-way RPC tracing where duration might not be measured.
+	// one-way RPC tracing where duration might not be measured.
 	Flush()
 }

--- a/span.go
+++ b/span.go
@@ -25,6 +25,13 @@ type Span interface {
 	// value is persisted.
 	Tag(string, string)
 
-	// Finish the Span and send to Reporter.
+	// Finish the Span and send to Reporter. If DelaySend option was used at
+	// span creation time, Finish will not send the span to the reporter. It then
+	// becomes the user's responsibility to get the span reporter (by using Flush)
 	Finish()
+
+	// Flush the Span to the Reporter (regardless of being finished or not)
+	// This can be used if the DelaySend SpanOption was set or when dealing with
+	// One-way RPC tracing where duration might not be measured.
+	Flush()
 }

--- a/span_implementation.go
+++ b/span_implementation.go
@@ -11,9 +11,9 @@ import (
 type spanImpl struct {
 	mtx sync.RWMutex
 	model.SpanModel
-	tracer      *Tracer
-	mustCollect int32 // used as atomic bool (1 = true, 0 = false)
-	delaySend   bool
+	tracer        *Tracer
+	mustCollect   int32 // used as atomic bool (1 = true, 0 = false)
+	flushOnFinish bool
 }
 
 func (s *spanImpl) Context() model.SpanContext {
@@ -65,7 +65,7 @@ func (s *spanImpl) Tag(key, value string) {
 func (s *spanImpl) Finish() {
 	if atomic.CompareAndSwapInt32(&s.mustCollect, 1, 0) {
 		s.Duration = time.Since(s.Timestamp)
-		if !s.delaySend {
+		if s.flushOnFinish {
 			s.tracer.reporter.Send(s.SpanModel)
 		}
 	}

--- a/span_implementation.go
+++ b/span_implementation.go
@@ -13,6 +13,7 @@ type spanImpl struct {
 	model.SpanModel
 	tracer      *Tracer
 	mustCollect int32 // used as atomic bool (1 = true, 0 = false)
+	delaySend   bool
 }
 
 func (s *spanImpl) Context() model.SpanContext {
@@ -64,6 +65,14 @@ func (s *spanImpl) Tag(key, value string) {
 func (s *spanImpl) Finish() {
 	if atomic.CompareAndSwapInt32(&s.mustCollect, 1, 0) {
 		s.Duration = time.Since(s.Timestamp)
+		if !s.delaySend {
+			s.tracer.reporter.Send(s.SpanModel)
+		}
+	}
+}
+
+func (s *spanImpl) Flush() {
+	if s.SpanModel.Debug || (s.SpanModel.Sampled != nil && *s.SpanModel.Sampled) {
 		s.tracer.reporter.Send(s.SpanModel)
 	}
 }

--- a/span_options.go
+++ b/span_options.go
@@ -62,12 +62,13 @@ func Tags(tags map[string]string) SpanOption {
 	}
 }
 
-// DelaySend will disable span.Finish() to send the span to the reporter
-// automatically. This then becomes the responsibility of the user. This is
-// available if late tag data is expected to be available after the required
-// finish time of the span.
-func DelaySend() SpanOption {
+// FlushOnFinish when set to false will disable span.Finish() to send the Span
+// to the Reporter automatically (which is the default behavior). If set to
+// false, having the Span be reported becomes the responsibility of the user.
+// This is available if late tag data is expected to be only available after the
+// required finish time of the Span.
+func FlushOnFinish(b bool) SpanOption {
 	return func(t *Tracer, s *spanImpl) {
-		s.delaySend = true
+		s.flushOnFinish = b
 	}
 }

--- a/span_options.go
+++ b/span_options.go
@@ -61,3 +61,13 @@ func Tags(tags map[string]string) SpanOption {
 		}
 	}
 }
+
+// DelaySend will disable span.Finish() to send the span to the reporter
+// automatically. This then becomes the responsibility of the user. This is
+// available if late tag data is expected to be available after the required
+// finish time of the span.
+func DelaySend() SpanOption {
+	return func(t *Tracer, s *spanImpl) {
+		s.delaySend = true
+	}
+}

--- a/span_options.go
+++ b/span_options.go
@@ -51,3 +51,13 @@ func RemoteEndpoint(e *model.Endpoint) SpanOption {
 		s.RemoteEndpoint = e
 	}
 }
+
+// Tags sets initial tags for the span being created. If default tracer tags
+// are present they will be overwritten on key collisions.
+func Tags(tags map[string]string) SpanOption {
+	return func(t *Tracer, s *spanImpl) {
+		for k, v := range tags {
+			s.Tags[k] = v
+		}
+	}
+}

--- a/span_test.go
+++ b/span_test.go
@@ -101,16 +101,26 @@ func TestTagsSpanOption(t *testing.T) {
 	}
 }
 
-func TestDelaySendSpanOption(t *testing.T) {
+func TestFlushOnFinishSpanOption(t *testing.T) {
 	rec := recorder.NewReporter()
 	defer rec.Close()
 	tracer, _ := NewTracer(rec)
 
-	span := tracer.StartSpan("test", DelaySend())
+	span := tracer.StartSpan("test")
 	time.Sleep(5 * time.Millisecond)
 	span.Finish()
 
 	spans := rec.Flush()
+
+	if want, have := 1, len(spans); want != have {
+		t.Errorf("Spans want: %d, have %d", want, have)
+	}
+
+	span = tracer.StartSpan("test", FlushOnFinish(false))
+	time.Sleep(5 * time.Millisecond)
+	span.Finish()
+
+	spans = rec.Flush()
 
 	if want, have := 0, len(spans); want != have {
 		t.Errorf("Spans want: %d, have %d", want, have)

--- a/span_test.go
+++ b/span_test.go
@@ -69,3 +69,33 @@ func TestRemoteEndpoint(t *testing.T) {
 		t.Errorf("RemoteEndpoint want nil, have %+v", have)
 	}
 }
+
+func TestTagsSpanOption(t *testing.T) {
+	rec := recorder.NewReporter()
+	defer rec.Close()
+	tracerTags := map[string]string{
+		"key1": "value1",
+		"key2": "will_be_overwritten",
+	}
+	tracer, err := NewTracer(rec, WithTags(tracerTags))
+	if err != nil {
+		t.Fatalf("expected valid tracer, got error: %+v", err)
+	}
+
+	spanTags := map[string]string{
+		"key2": "value2",
+		"key3": "value3",
+	}
+	span := tracer.StartSpan("test", Tags(spanTags))
+	defer span.Finish()
+
+	allTags := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+
+	if want, have := allTags, span.(*spanImpl).Tags; !reflect.DeepEqual(want, have) {
+		t.Errorf("Tags want: %+v, have: %+v", want, have)
+	}
+}

--- a/tracer.go
+++ b/tracer.go
@@ -68,7 +68,6 @@ func (t *Tracer) StartSpan(name string, options ...SpanOption) Span {
 		SpanModel: model.SpanModel{
 			Kind:          model.Undetermined,
 			Name:          name,
-			Timestamp:     time.Now(),
 			LocalEndpoint: t.localEndpoint,
 			Annotations:   make([]model.Annotation, 0),
 			Tags:          make(map[string]string),
@@ -76,6 +75,12 @@ func (t *Tracer) StartSpan(name string, options ...SpanOption) Span {
 		tracer: t,
 	}
 
+	// add default tracer tags to span
+	for k, v := range t.defaultTags {
+		s.Tag(k, v)
+	}
+
+	// handle provided functional options
 	for _, option := range options {
 		option(t, s)
 	}
@@ -117,9 +122,9 @@ func (t *Tracer) StartSpan(name string, options ...SpanOption) Span {
 		}
 	}
 
-	// add default tags to span
-	for k, v := range t.defaultTags {
-		s.Tag(k, v)
+	// add start time
+	if s.Timestamp.IsZero() {
+		s.Timestamp = time.Now()
 	}
 
 	return s

--- a/tracer.go
+++ b/tracer.go
@@ -72,7 +72,8 @@ func (t *Tracer) StartSpan(name string, options ...SpanOption) Span {
 			Annotations:   make([]model.Annotation, 0),
 			Tags:          make(map[string]string),
 		},
-		tracer: t,
+		flushOnFinish: true,
+		tracer:        t,
 	}
 
 	// add default tracer tags to span


### PR DESCRIPTION
The `DelaySend` SpanOption can be set when creating a Span with `tracer.StartSpan`. This allows one to decouple `span.Finish` duration timing from also automatically sending the `Span` to the Reporter. With `DelaySend` the responsibility of sending the Span off to the Reporter is with the user. The user can call the new `span.Flush` method to send the Span to the Reporter. 

`span.Flush` allows the user to send a Span to the Reporter regardless of duration being set or not. This function can be used in combination with `DelaySend` to add delayed Tags to an already finished Span or when dealing with One-way RPC where duration might not be timed. 