### PR TITLE
made randomTimestamped traceID generator AWS X-Ray friendly

### DIFF
--- a/idgenerator/idgenerator.go
+++ b/idgenerator/idgenerator.go
@@ -91,14 +91,14 @@ func (r *randomID128) SpanID(traceID model.TraceID) (id model.ID) {
 	return
 }
 
-// randomTimestamped can generate 128 bit time sortable traceid's and 64 bit
-// spanid's.
+// randomTimestamped can generate 128 bit time sortable traceid's compatible
+// with AWS X-Ray and 64 bit spanid's.
 type randomTimestamped struct{}
 
 func (t *randomTimestamped) TraceID() (id model.TraceID) {
 	seededIDLock.Lock()
 	id = model.TraceID{
-		High: uint64(time.Now().UnixNano()),
+		High: uint64(time.Now().Unix()<<32) + uint64(seededIDGen.Int31()),
 		Low:  uint64(seededIDGen.Int63()),
 	}
 	seededIDLock.Unlock()

--- a/idgenerator/idgenerator_test.go
+++ b/idgenerator/idgenerator_test.go
@@ -107,10 +107,10 @@ func TestRandomTimeStamped(t *testing.T) {
 
 	var latestTS uint64
 	for idx, traceID := range ids {
-		if new, old := traceID.High, latestTS; new < old {
+		if new, old := traceID.High>>32, latestTS; new < old {
 			t.Errorf("[%d] expected a higher timestamp part in traceid but got: old: %d new: %d", idx, old, new)
 		}
-		latestTS = traceID.High
+		latestTS = traceID.High >> 32
 	}
 
 }

--- a/middleware/http/transport.go
+++ b/middleware/http/transport.go
@@ -44,7 +44,7 @@ func TransportTrace(enable bool) TransportOption {
 }
 
 // NewTransport returns a new Zipkin instrumented http RoundTripper which can be
-// used with a standad library http Client.
+// used with a standard library http Client.
 func NewTransport(tracer *zipkin.Tracer, options ...TransportOption) (http.RoundTripper, error) {
 	if tracer == nil {
 		return nil, ErrValidTracerRequired


### PR DESCRIPTION
randomTimestamped generator used to create TraceID's using 64 bit unix epoch timestamps in nanoseconds + 64 bit random.

This PR changes behavior to 32 bit unix epoch timestamps in seconds + 96 bit random, in line with AWS X-Ray trace IDs.