### PR TITLE
do not restart trace on invalid Flag header values. fixes #53

### DIFF
--- a/propagation/b3/grpc_test.go
+++ b/propagation/b3/grpc_test.go
@@ -90,12 +90,23 @@ func TestGRPCExtractSampledErrors(t *testing.T) {
 }
 
 func TestGRPCExtractFlagsErrors(t *testing.T) {
-	md := metadata.Pairs(b3.Flags, "2")
-
-	_, err := b3.ExtractGRPC(&md)()
-
-	if want, have := b3.ErrInvalidFlagsHeader, err; want != have {
-		t.Errorf("SpanContext Error want %+v, have %+v", want, have)
+	values := map[string]bool{
+		"1":    true,  // only acceptable Flags value, debug switches to true
+		"true": false, // true is not a valid value for Flags
+		"3":    false, // Flags is not a bitset
+		"6":    false, // Flags is not a bitset
+		"7":    false, // Flags is not a bitset
+	}
+	for value, debug := range values {
+		md := metadata.Pairs(b3.Flags, value)
+		spanContext, err := b3.ExtractGRPC(&md)()
+		if err != nil {
+			// Flags should not trigger failed extraction
+			t.Fatalf("ExtractHTTP failed: %+v", err)
+		}
+		if want, have := debug, spanContext.Debug; want != have {
+			t.Errorf("SpanContext Error want %t, have %t", want, have)
+		}
 	}
 }
 

--- a/propagation/b3/spancontext.go
+++ b/propagation/b3/spancontext.go
@@ -35,16 +35,13 @@ func ParseHeaders(
 		return nil, ErrInvalidSampledHeader
 	}
 
-	switch hdrFlags {
-	case "", "0":
-		// sc.Debug = false
-	case "1":
+	// The only accepted value for Flags is "1". This will set Debug to true. All
+	// other values and omission of header will be ignored.
+	if hdrFlags == "1" {
 		sc.Debug = true
 		if sc.Sampled != nil {
 			sc.Sampled = nil
 		}
-	default:
-		return nil, ErrInvalidFlagsHeader
 	}
 
 	if hdrTraceID != "" {


### PR DESCRIPTION
Let's be more lenient on incorrect `X-B3-Flags` values and not restart traces on it.

Only valid value that has effect is "1" which will set SpanContext Debug to true.
