### PR TITLE
Removes tag http url.

### DIFF
--- a/middleware/http/client.go
+++ b/middleware/http/client.go
@@ -95,7 +95,6 @@ func (c *Client) DoWithAppSpan(req *http.Request, name string) (res *http.Respon
 	appSpan := c.tracer.StartSpan(name, zipkin.Parent(parentContext))
 
 	zipkin.TagHTTPMethod.Set(appSpan, req.Method)
-	zipkin.TagHTTPUrl.Set(appSpan, req.URL.String())
 	zipkin.TagHTTPPath.Set(appSpan, req.URL.Path)
 
 	res, err = c.Client.Do(

--- a/middleware/http/transport.go
+++ b/middleware/http/transport.go
@@ -100,7 +100,6 @@ func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 	}
 
 	zipkin.TagHTTPMethod.Set(sp, req.Method)
-	zipkin.TagHTTPUrl.Set(sp, req.URL.String())
 	zipkin.TagHTTPPath.Set(sp, req.URL.Path)
 
 	_ = b3.InjectHTTP(req)(sp.Context())


### PR DESCRIPTION
As mentioned before, `tagHTTPUrl` should not include the query parameters as they could include sensitive data like `api_keys` or `tokens` and without the query parameters it is merely the `tagHTTPPath` so in this PR we get rid of them.