### PR TITLE
middleware: Improved http.Handler logic and added RequestSampler option 

### DIFF
--- a/middleware/http/server.go
+++ b/middleware/http/server.go
@@ -163,104 +163,104 @@ func (r *rwInterceptor) getResponseSize() string {
 	return strconv.FormatUint(atomic.LoadUint64(&r.size), 10)
 }
 
-func (t *rwInterceptor) wrap() http.ResponseWriter {
+func (r *rwInterceptor) wrap() http.ResponseWriter {
 	var (
-		hj, i0 = t.w.(http.Hijacker)
-		cn, i1 = t.w.(http.CloseNotifier)
-		pu, i2 = t.w.(http.Pusher)
-		fl, i3 = t.w.(http.Flusher)
-		rf, i4 = t.w.(io.ReaderFrom)
+		hj, i0 = r.w.(http.Hijacker)
+		cn, i1 = r.w.(http.CloseNotifier)
+		pu, i2 = r.w.(http.Pusher)
+		fl, i3 = r.w.(http.Flusher)
+		rf, i4 = r.w.(io.ReaderFrom)
 	)
 
 	switch {
 	case !i0 && !i1 && !i2 && !i3 && !i4:
 		return struct {
 			http.ResponseWriter
-		}{t}
+		}{r}
 	case !i0 && !i1 && !i2 && !i3 && i4:
 		return struct {
 			http.ResponseWriter
 			io.ReaderFrom
-		}{t, rf}
+		}{r, rf}
 	case !i0 && !i1 && !i2 && i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.Flusher
-		}{t, fl}
+		}{r, fl}
 	case !i0 && !i1 && !i2 && i3 && i4:
 		return struct {
 			http.ResponseWriter
 			http.Flusher
 			io.ReaderFrom
-		}{t, fl, rf}
+		}{r, fl, rf}
 	case !i0 && !i1 && i2 && !i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.Pusher
-		}{t, pu}
+		}{r, pu}
 	case !i0 && !i1 && i2 && !i3 && i4:
 		return struct {
 			http.ResponseWriter
 			http.Pusher
 			io.ReaderFrom
-		}{t, pu, rf}
+		}{r, pu, rf}
 	case !i0 && !i1 && i2 && i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.Pusher
 			http.Flusher
-		}{t, pu, fl}
+		}{r, pu, fl}
 	case !i0 && !i1 && i2 && i3 && i4:
 		return struct {
 			http.ResponseWriter
 			http.Pusher
 			http.Flusher
 			io.ReaderFrom
-		}{t, pu, fl, rf}
+		}{r, pu, fl, rf}
 	case !i0 && i1 && !i2 && !i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.CloseNotifier
-		}{t, cn}
+		}{r, cn}
 	case !i0 && i1 && !i2 && !i3 && i4:
 		return struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			io.ReaderFrom
-		}{t, cn, rf}
+		}{r, cn, rf}
 	case !i0 && i1 && !i2 && i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Flusher
-		}{t, cn, fl}
+		}{r, cn, fl}
 	case !i0 && i1 && !i2 && i3 && i4:
 		return struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Flusher
 			io.ReaderFrom
-		}{t, cn, fl, rf}
+		}{r, cn, fl, rf}
 	case !i0 && i1 && i2 && !i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Pusher
-		}{t, cn, pu}
+		}{r, cn, pu}
 	case !i0 && i1 && i2 && !i3 && i4:
 		return struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Pusher
 			io.ReaderFrom
-		}{t, cn, pu, rf}
+		}{r, cn, pu, rf}
 	case !i0 && i1 && i2 && i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Pusher
 			http.Flusher
-		}{t, cn, pu, fl}
+		}{r, cn, pu, fl}
 	case !i0 && i1 && i2 && i3 && i4:
 		return struct {
 			http.ResponseWriter
@@ -268,51 +268,51 @@ func (t *rwInterceptor) wrap() http.ResponseWriter {
 			http.Pusher
 			http.Flusher
 			io.ReaderFrom
-		}{t, cn, pu, fl, rf}
+		}{r, cn, pu, fl, rf}
 	case i0 && !i1 && !i2 && !i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
-		}{t, hj}
+		}{r, hj}
 	case i0 && !i1 && !i2 && !i3 && i4:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
 			io.ReaderFrom
-		}{t, hj, rf}
+		}{r, hj, rf}
 	case i0 && !i1 && !i2 && i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
 			http.Flusher
-		}{t, hj, fl}
+		}{r, hj, fl}
 	case i0 && !i1 && !i2 && i3 && i4:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
 			http.Flusher
 			io.ReaderFrom
-		}{t, hj, fl, rf}
+		}{r, hj, fl, rf}
 	case i0 && !i1 && i2 && !i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
 			http.Pusher
-		}{t, hj, pu}
+		}{r, hj, pu}
 	case i0 && !i1 && i2 && !i3 && i4:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
 			http.Pusher
 			io.ReaderFrom
-		}{t, hj, pu, rf}
+		}{r, hj, pu, rf}
 	case i0 && !i1 && i2 && i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
 			http.Pusher
 			http.Flusher
-		}{t, hj, pu, fl}
+		}{r, hj, pu, fl}
 	case i0 && !i1 && i2 && i3 && i4:
 		return struct {
 			http.ResponseWriter
@@ -320,27 +320,27 @@ func (t *rwInterceptor) wrap() http.ResponseWriter {
 			http.Pusher
 			http.Flusher
 			io.ReaderFrom
-		}{t, hj, pu, fl, rf}
+		}{r, hj, pu, fl, rf}
 	case i0 && i1 && !i2 && !i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
-		}{t, hj, cn}
+		}{r, hj, cn}
 	case i0 && i1 && !i2 && !i3 && i4:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
 			io.ReaderFrom
-		}{t, hj, cn, rf}
+		}{r, hj, cn, rf}
 	case i0 && i1 && !i2 && i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
 			http.Flusher
-		}{t, hj, cn, fl}
+		}{r, hj, cn, fl}
 	case i0 && i1 && !i2 && i3 && i4:
 		return struct {
 			http.ResponseWriter
@@ -348,14 +348,14 @@ func (t *rwInterceptor) wrap() http.ResponseWriter {
 			http.CloseNotifier
 			http.Flusher
 			io.ReaderFrom
-		}{t, hj, cn, fl, rf}
+		}{r, hj, cn, fl, rf}
 	case i0 && i1 && i2 && !i3 && !i4:
 		return struct {
 			http.ResponseWriter
 			http.Hijacker
 			http.CloseNotifier
 			http.Pusher
-		}{t, hj, cn, pu}
+		}{r, hj, cn, pu}
 	case i0 && i1 && i2 && !i3 && i4:
 		return struct {
 			http.ResponseWriter
@@ -363,7 +363,7 @@ func (t *rwInterceptor) wrap() http.ResponseWriter {
 			http.CloseNotifier
 			http.Pusher
 			io.ReaderFrom
-		}{t, hj, cn, pu, rf}
+		}{r, hj, cn, pu, rf}
 	case i0 && i1 && i2 && i3 && !i4:
 		return struct {
 			http.ResponseWriter
@@ -371,7 +371,7 @@ func (t *rwInterceptor) wrap() http.ResponseWriter {
 			http.CloseNotifier
 			http.Pusher
 			http.Flusher
-		}{t, hj, cn, pu, fl}
+		}{r, hj, cn, pu, fl}
 	case i0 && i1 && i2 && i3 && i4:
 		return struct {
 			http.ResponseWriter
@@ -380,10 +380,10 @@ func (t *rwInterceptor) wrap() http.ResponseWriter {
 			http.Pusher
 			http.Flusher
 			io.ReaderFrom
-		}{t, hj, cn, pu, fl, rf}
+		}{r, hj, cn, pu, fl, rf}
 	default:
 		return struct {
 			http.ResponseWriter
-		}{t}
+		}{r}
 	}
 }

--- a/middleware/http/server.go
+++ b/middleware/http/server.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"io"
 	"net/http"
 	"strconv"
 	"sync/atomic"
@@ -114,7 +115,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	// call next http Handler func using our updated context.
-	h.next.ServeHTTP(ri, r.WithContext(ctx))
+	h.next.ServeHTTP(ri.wrap(), r.WithContext(ctx))
 }
 
 // rwInterceptor intercepts the ResponseWriter so it can track response size
@@ -146,4 +147,229 @@ func (r *rwInterceptor) getStatusCode() int {
 
 func (r *rwInterceptor) getResponseSize() string {
 	return strconv.FormatUint(atomic.LoadUint64(&r.size), 10)
+}
+
+func (t *rwInterceptor) wrap() http.ResponseWriter {
+	var (
+		hj, i0 = t.w.(http.Hijacker)
+		cn, i1 = t.w.(http.CloseNotifier)
+		pu, i2 = t.w.(http.Pusher)
+		fl, i3 = t.w.(http.Flusher)
+		rf, i4 = t.w.(io.ReaderFrom)
+	)
+
+	switch {
+	case !i0 && !i1 && !i2 && !i3 && !i4:
+		return struct {
+			http.ResponseWriter
+		}{t}
+	case !i0 && !i1 && !i2 && !i3 && i4:
+		return struct {
+			http.ResponseWriter
+			io.ReaderFrom
+		}{t, rf}
+	case !i0 && !i1 && !i2 && i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+		}{t, fl}
+	case !i0 && !i1 && !i2 && i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+		}{t, fl, rf}
+	case !i0 && !i1 && i2 && !i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.Pusher
+		}{t, pu}
+	case !i0 && !i1 && i2 && !i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.Pusher
+			io.ReaderFrom
+		}{t, pu, rf}
+	case !i0 && !i1 && i2 && i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.Pusher
+			http.Flusher
+		}{t, pu, fl}
+	case !i0 && !i1 && i2 && i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.Pusher
+			http.Flusher
+			io.ReaderFrom
+		}{t, pu, fl, rf}
+	case !i0 && i1 && !i2 && !i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+		}{t, cn}
+	case !i0 && i1 && !i2 && !i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+		}{t, cn, rf}
+	case !i0 && i1 && !i2 && i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Flusher
+		}{t, cn, fl}
+	case !i0 && i1 && !i2 && i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Flusher
+			io.ReaderFrom
+		}{t, cn, fl, rf}
+	case !i0 && i1 && i2 && !i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Pusher
+		}{t, cn, pu}
+	case !i0 && i1 && i2 && !i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Pusher
+			io.ReaderFrom
+		}{t, cn, pu, rf}
+	case !i0 && i1 && i2 && i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Pusher
+			http.Flusher
+		}{t, cn, pu, fl}
+	case !i0 && i1 && i2 && i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Pusher
+			http.Flusher
+			io.ReaderFrom
+		}{t, cn, pu, fl, rf}
+	case i0 && !i1 && !i2 && !i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+		}{t, hj}
+	case i0 && !i1 && !i2 && !i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+		}{t, hj, rf}
+	case i0 && !i1 && !i2 && i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.Flusher
+		}{t, hj, fl}
+	case i0 && !i1 && !i2 && i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.Flusher
+			io.ReaderFrom
+		}{t, hj, fl, rf}
+	case i0 && !i1 && i2 && !i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.Pusher
+		}{t, hj, pu}
+	case i0 && !i1 && i2 && !i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.Pusher
+			io.ReaderFrom
+		}{t, hj, pu, rf}
+	case i0 && !i1 && i2 && i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.Pusher
+			http.Flusher
+		}{t, hj, pu, fl}
+	case i0 && !i1 && i2 && i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.Pusher
+			http.Flusher
+			io.ReaderFrom
+		}{t, hj, pu, fl, rf}
+	case i0 && i1 && !i2 && !i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.CloseNotifier
+		}{t, hj, cn}
+	case i0 && i1 && !i2 && !i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.CloseNotifier
+			io.ReaderFrom
+		}{t, hj, cn, rf}
+	case i0 && i1 && !i2 && i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.CloseNotifier
+			http.Flusher
+		}{t, hj, cn, fl}
+	case i0 && i1 && !i2 && i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.CloseNotifier
+			http.Flusher
+			io.ReaderFrom
+		}{t, hj, cn, fl, rf}
+	case i0 && i1 && i2 && !i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.CloseNotifier
+			http.Pusher
+		}{t, hj, cn, pu}
+	case i0 && i1 && i2 && !i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.CloseNotifier
+			http.Pusher
+			io.ReaderFrom
+		}{t, hj, cn, pu, rf}
+	case i0 && i1 && i2 && i3 && !i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.CloseNotifier
+			http.Pusher
+			http.Flusher
+		}{t, hj, cn, pu, fl}
+	case i0 && i1 && i2 && i3 && i4:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.CloseNotifier
+			http.Pusher
+			http.Flusher
+			io.ReaderFrom
+		}{t, hj, cn, pu, fl, rf}
+	default:
+		return struct {
+			http.ResponseWriter
+		}{t}
+	}
 }


### PR DESCRIPTION
We had our own rwInterceptor logic to figure out response sizes and http status codes but it was incomplete allowing for breaking existing code as intercepting http.Handlers is not as trivial as it seems. For more information see: https://github.com/felixge/httpsnoop#why-this-package-exists

This PR uses the idea borrowed from httpsnoop for intercepting the handlers in a better and most of all transparent way.

Also added is the ability to add a callback function for making sampling decisions for root spans based on the HTTP request details.