### PR TITLE
use builtin standard lib net/http defined http constants

### DIFF
--- a/middleware/http/client.go
+++ b/middleware/http/client.go
@@ -113,10 +113,10 @@ func (c *Client) DoWithAppSpan(req *http.Request, name string) (res *http.Respon
 	if res.ContentLength > 0 {
 		zipkin.TagHTTPResponseSize.Set(appSpan, strconv.FormatInt(res.ContentLength, 10))
 	}
-	if res.StatusCode < 200 || res.StatusCode > 299 {
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
 		statusCode := strconv.FormatInt(int64(res.StatusCode), 10)
 		zipkin.TagHTTPStatusCode.Set(appSpan, statusCode)
-		if res.StatusCode > 399 {
+		if res.StatusCode >= http.StatusBadRequest {
 			zipkin.TagError.Set(appSpan, statusCode)
 		}
 	}

--- a/middleware/http/server.go
+++ b/middleware/http/server.go
@@ -112,13 +112,13 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// create http.ResponseWriter interceptor for tracking response size and
 	// status code.
-	ri := &rwInterceptor{w: w, statusCode: 200}
+	ri := &rwInterceptor{w: w, statusCode: http.StatusOK}
 
 	// tag found response size and status code on exit
 	defer func() {
 		code := ri.getStatusCode()
 		sCode := strconv.Itoa(code)
-		if code > 399 {
+		if code >= http.StatusBadRequest {
 			zipkin.TagError.Set(sp, sCode)
 		}
 		zipkin.TagHTTPStatusCode.Set(sp, sCode)

--- a/middleware/http/server_test.go
+++ b/middleware/http/server_test.go
@@ -35,7 +35,7 @@ func TestHTTPHandlerWrapping(t *testing.T) {
 		responseBuf  = bytes.NewBufferString("oh oh we have a 404")
 		headers      = make(http.Header)
 		spanName     = "wrapper_test"
-		code         = 404
+		code         = http.StatusNotFound
 	)
 	headers.Add("some-key", "some-value")
 	headers.Add("other-key", "other-value")
@@ -121,7 +121,7 @@ func TestHTTPDefaultSpanName(t *testing.T) {
 		t.Fatalf("unable to create request")
 	}
 
-	httpHandlerFunc := http.HandlerFunc(httpHandler(200, nil, bytes.NewBufferString("")))
+	httpHandlerFunc := http.HandlerFunc(httpHandler(http.StatusOK, nil, bytes.NewBufferString("")))
 
 	handler := mw.NewServerMiddleware(tr)(httpHandlerFunc)
 
@@ -146,7 +146,7 @@ func TestHTTPRequestSampler(t *testing.T) {
 		httpRecorder    = httptest.NewRecorder()
 		requestBuf      = bytes.NewBufferString("incoming data")
 		methodType      = "POST"
-		httpHandlerFunc = http.HandlerFunc(httpHandler(200, nil, bytes.NewBufferString("")))
+		httpHandlerFunc = http.HandlerFunc(httpHandler(http.StatusOK, nil, bytes.NewBufferString("")))
 	)
 
 	samplers := [](func(r *http.Request) bool){

--- a/middleware/http/transport.go
+++ b/middleware/http/transport.go
@@ -115,10 +115,10 @@ func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 	if res.ContentLength > 0 {
 		zipkin.TagHTTPResponseSize.Set(sp, strconv.FormatInt(res.ContentLength, 10))
 	}
-	if res.StatusCode < 200 || res.StatusCode > 299 {
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
 		statusCode := strconv.FormatInt(int64(res.StatusCode), 10)
 		zipkin.TagHTTPStatusCode.Set(sp, statusCode)
-		if res.StatusCode > 399 {
+		if res.StatusCode >= http.StatusBadRequest {
 			zipkin.TagError.Set(sp, statusCode)
 		}
 	}


### PR DESCRIPTION
http constants already defined here. why not reference them instead
* https://golang.org/src/net/http/status.go
Note there is no 299 or 399 code. so use the next increment which is defined and change > to >=