### PR TITLE
fixes go vet issue with repeating struct tag on tip

### DIFF
--- a/model/span.go
+++ b/model/span.go
@@ -33,8 +33,8 @@ type SpanModel struct {
 	SpanContext
 	Name           string            `json:"name,omitempty"`
 	Kind           Kind              `json:"kind,omitempty"`
-	Timestamp      time.Time         `json:"timestamp,omitempty"`
-	Duration       time.Duration     `json:"duration,omitempty"`
+	Timestamp      time.Time         `json:"-"`
+	Duration       time.Duration     `json:"-"`
 	Shared         bool              `json:"shared,omitempty"`
 	LocalEndpoint  *Endpoint         `json:"localEndpoint,omitempty"`
 	RemoteEndpoint *Endpoint         `json:"remoteEndpoint,omitempty"`
@@ -82,13 +82,13 @@ func (s SpanModel) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(&struct {
-		Timestamp int64 `json:"timestamp,omitempty"`
-		Duration  int64 `json:"duration,omitempty"`
+		T int64 `json:"timestamp,omitempty"`
+		D int64 `json:"duration,omitempty"`
 		Alias
 	}{
-		Timestamp: timestamp,
-		Duration:  s.Duration.Nanoseconds() / 1e3,
-		Alias:     (Alias)(s),
+		T:     timestamp,
+		D:     s.Duration.Nanoseconds() / 1e3,
+		Alias: (Alias)(s),
 	})
 }
 
@@ -97,8 +97,8 @@ func (s SpanModel) MarshalJSON() ([]byte, error) {
 func (s *SpanModel) UnmarshalJSON(b []byte) error {
 	type Alias SpanModel
 	span := &struct {
-		TimeStamp uint64 `json:"timestamp,omitempty"`
-		Duration  uint64 `json:"duration,omitempty"`
+		T uint64 `json:"timestamp,omitempty"`
+		D uint64 `json:"duration,omitempty"`
 		*Alias
 	}{
 		Alias: (*Alias)(s),
@@ -109,10 +109,10 @@ func (s *SpanModel) UnmarshalJSON(b []byte) error {
 	if s.ID < 1 {
 		return ErrValidIDRequired
 	}
-	if span.TimeStamp > 0 {
-		s.Timestamp = time.Unix(0, int64(span.TimeStamp)*1e3)
+	if span.T > 0 {
+		s.Timestamp = time.Unix(0, int64(span.T)*1e3)
 	}
-	s.Duration = time.Duration(span.Duration*1e3) * time.Nanosecond
+	s.Duration = time.Duration(span.D*1e3) * time.Nanosecond
 	if s.LocalEndpoint.Empty() {
 		s.LocalEndpoint = nil
 	}


### PR DESCRIPTION
Latest Go tip errors out on `go vet`:
```
# github.com/openzipkin/zipkin-go/model
model/span.go:87: struct field Timestamp repeats json tag "timestamp" also at model/span.go:85
model/span.go:87: struct field Duration repeats json tag "duration" also at model/span.go:86
make: *** [vet] Error 2
The command "make test vet lint bench" exited with 2.
```
We're using a special technique for converting property types that need different Go types between JSON representation and Go struct representation. Since we needed both to be annotated with JSON tags as we have to also change character casing we ran into struct tag redeclaration issues. 

By making our Go struct model explicitly set JSON omit tags and our Marshal/Unmarshal functions use different property names we avoid repeated json tags.