### PR TITLE
fix(#80): removes http.response.size when response body is empty.

### DIFF
--- a/middleware/http/server.go
+++ b/middleware/http/server.go
@@ -124,7 +124,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			zipkin.TagError.Set(sp, sCode)
 		}
 		zipkin.TagHTTPStatusCode.Set(sp, sCode)
-		if h.tagResponseSize {
+		if h.tagResponseSize && ri.size > 0 {
 			zipkin.TagHTTPResponseSize.Set(sp, ri.getResponseSize())
 		}
 		sp.Finish()


### PR DESCRIPTION
Related to #80 and #81

Ping @basvanbeek 