### PR TITLE
NewEndpoint fix: use empty ipv4 or ipv6 if applicable (fixes #85)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 
 install:
   - go get -d -t ./...
-  - go get -u github.com/golang/lint/...
+  - if [[ ! $TRAVIS_GO_VERSION = 1.8* ]]; then go get -u golang.org/x/lint/golint ; fi
 
 script:
   - make test vet lint bench

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,7 @@ bench:
 .PHONY: lint
 lint:
 	# Ignore grep's exit code since no match returns 1.
-	-golint ./... | grep --invert-match -E '^.*\.pb\.go|^thrift'
-	@
-	@! (golint ./... | grep --invert-match -E '^.*\.pb\.go|^thrift' | read dummy)
+	-if [[ ! $TRAVIS_GO_VERSION = 1.8* ]]; then echo 'linting...' ; golint ./... ; fi
 
 .PHONY: vet
 vet:

--- a/endpoint.go
+++ b/endpoint.go
@@ -62,10 +62,5 @@ func NewEndpoint(serviceName string, hostPort string) (*model.Endpoint, error) {
 		}
 	}
 
-	// default to 0 filled 4 byte array for IPv4 if IPv6 only host was found
-	if e.IPv4 == nil {
-		e.IPv4 = make([]byte, 4)
-	}
-
 	return e, nil
 }

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -23,7 +23,7 @@ const (
 )
 
 var (
-	ipv4HostPort    = "localhost:" + fmt.Sprintf("%d", port)
+	ipv4HostPort    = "127.0.0.1:" + fmt.Sprintf("%d", port)
 	ipv6HostPort    = "[2001:db8::68]:" + fmt.Sprintf("%d", port)
 	ipv4ForHostPort = net.IPv4(127, 0, 0, 1)
 	ipv6ForHostPort = net.ParseIP("2001:db8::68")
@@ -128,6 +128,10 @@ func TestNewEndpointIpv4Success(t *testing.T) {
 	if port != endpoint.Port {
 		t.Fatalf("expected port %d, got %d", port, endpoint.Port)
 	}
+
+	if endpoint.IPv6 != nil {
+		t.Fatalf("expected empty IPv6 got %+v", endpoint.IPv6)
+	}
 }
 
 func TestNewEndpointIpv6Success(t *testing.T) {
@@ -147,5 +151,9 @@ func TestNewEndpointIpv6Success(t *testing.T) {
 
 	if port != endpoint.Port {
 		t.Fatalf("expected port %d, got %d", port, endpoint.Port)
+	}
+
+	if endpoint.IPv4 != nil {
+		t.Fatalf("expected empty IPv4 got %+v", endpoint.IPv4)
 	}
 }


### PR DESCRIPTION
IPv4 was set to '0.0.0.0' on IPv6 only hosts. This is a relic from v1 thrift days but does not belong in this v2 library. This fixes #85.