### PR TITLE
Handle empty spans when tagging

### DIFF
--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -93,8 +93,8 @@ func TestNewEndpointFailsDueToLookupIP(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
-	if !strings.Contains(err.Error(), "no such host") {
-		t.Fatalf("expected no such host error, got: %s", err.Error())
+	if _, ok := err.(*net.DNSError); !ok {
+		t.Fatalf("expected no such host error, got: %s", err)
 	}
 }
 

--- a/tags.go
+++ b/tags.go
@@ -19,5 +19,9 @@ const (
 
 // Set a standard Tag with a payload on provided Span.
 func (t Tag) Set(s Span, value string) {
+	if s == nil {
+		return
+	}
+
 	s.Tag(string(t), value)
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,0 +1,7 @@
+package zipkin
+
+import "testing"
+
+func TestTagNilSpan(t *testing.T) {
+	TagError.Set(nil, "any value really")
+}


### PR DESCRIPTION
This is a minor change targetted at making it more convenient to tag
directly a span in context, e.g.
 `TagError.Set(zipkin.SpanFromContext(ctx), "an error message")`

Previously, the code would crash if no span was available.