### PR TITLE
Adds SpanOrNoopFromContext convenience function

### DIFF
--- a/context.go
+++ b/context.go
@@ -4,6 +4,8 @@ import (
 	"context"
 )
 
+var defaultNoopSpan = &noopSpan{}
+
 // SpanFromContext retrieves a Zipkin Span from Go's context propagation
 // mechanism if found. If not found, returns nil.
 func SpanFromContext(ctx context.Context) Span {
@@ -11,6 +13,19 @@ func SpanFromContext(ctx context.Context) Span {
 		return s
 	}
 	return nil
+}
+
+// SpanOrNoopFromContext retrieves a Zipkin Span from Go's context propagation
+// mechanism if found. If not found, returns a noopSpan.
+// This function typically is used for modules that want to provide existing
+// Zipkin spans with additional data, but can't guarantee that spans are
+// properly propagated. It is preferred to use SpanFromContext() and test for
+// Nil instead of using this function.
+func SpanOrNoopFromContext(ctx context.Context) Span {
+	if s, ok := ctx.Value(spanKey).(Span); ok {
+		return s
+	}
+	return defaultNoopSpan
 }
 
 // NewContext stores a Zipkin Span into Go's context propagation mechanism.

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,25 @@
+package zipkin
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSpanOrNoopFromContext(t *testing.T) {
+	var (
+		ctx   = context.Background()
+		tr, _ = NewTracer(nil, WithLocalEndpoint(nil))
+		span  = tr.StartSpan("test")
+	)
+
+	if want, have := defaultNoopSpan, SpanOrNoopFromContext(ctx); want != have {
+		t.Errorf("Invalid response want %+v, have %+v", want, have)
+	}
+
+	ctx = NewContext(ctx, span)
+
+	if want, have := span, SpanOrNoopFromContext(ctx); want != have {
+		t.Errorf("Invalid response want %+v, have %+v", want, have)
+	}
+
+}


### PR DESCRIPTION
This solves concerns as expressed in: https://github.com/openzipkin/zipkin-go/pull/97

This typically is used in modular code where it is not guaranteed that spans are propagated in the resulting application binary. For this code it is advisable to test for nil but for those dead set on tracing API's having zero side effects this solves that issue.