### PR TITLE
chore: adds support for end time in spanImpl.

### DIFF
--- a/span_implementation.go
+++ b/span_implementation.go
@@ -85,6 +85,15 @@ func (s *spanImpl) Finish() {
 	}
 }
 
+func (s *spanImpl) FinishedWithDuration(d time.Duration) {
+	if atomic.CompareAndSwapInt32(&s.mustCollect, 1, 0) {
+		s.Duration = d
+		if s.flushOnFinish {
+			s.tracer.reporter.Send(s.SpanModel)
+		}
+	}
+}
+
 func (s *spanImpl) Flush() {
 	if s.SpanModel.Debug || (s.SpanModel.Sampled != nil && *s.SpanModel.Sampled) {
 		s.tracer.reporter.Send(s.SpanModel)


### PR DESCRIPTION
This PR adds a methods for finishing the span at a certain time. i have doubts about calling it `FinishAt` or `FinishedAt` (because you might pass a past time under general situations).

Ping @basvanbeek @stakhiv