### PR TITLE
feat: adds support for error handler in http client.

### DIFF
--- a/middleware/http/transport.go
+++ b/middleware/http/transport.go
@@ -73,7 +73,7 @@ func TransportTrace(enable bool) TransportOption {
 	}
 }
 
-// TransportTrace allows one to enable Go's net/http/httptrace.
+// TransportErrHandler allows to pass a custom error handler for the round trip
 func TransportErrHandler(h ErrHandler) TransportOption {
 	return func(t *transport) {
 		t.errHandler = h

--- a/middleware/http/transport_test.go
+++ b/middleware/http/transport_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,7 +9,38 @@ import (
 	zipkin "github.com/openzipkin/zipkin-go"
 )
 
-func TestRoundTripErrHandling(t *testing.T) {
+type errRoundTripper struct {
+	err error
+}
+
+func (r errRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, r.err
+}
+
+func TestRoundTripErrHandlingForRoundTripError(t *testing.T) {
+	expectedErr := errors.New("error message")
+	tracer, err := zipkin.NewTracer(nil)
+	if err != nil {
+		t.Fatalf("unexpected error when creating tracer: %v", err)
+	}
+	req, _ := http.NewRequest("GET", "localhost", nil)
+	transport, _ := NewTransport(
+		tracer,
+		TransportErrHandler(func(_ zipkin.Span, err error, statusCode int) {
+			if want, have := expectedErr, err; want != have {
+				t.Errorf("unexpected error, want %q, have %q", want, have)
+			}
+		}),
+		RoundTripper(&errRoundTripper{err: expectedErr}),
+	)
+
+	_, err = transport.RoundTrip(req)
+	if err == nil {
+		t.Fatalf("expected error: %v", expectedErr)
+	}
+}
+
+func TestRoundTripErrHandlingForStatusCode(t *testing.T) {
 	tcs := []struct {
 		actualStatusCode int
 		expectedError    int
@@ -40,11 +72,14 @@ func TestRoundTripErrHandling(t *testing.T) {
 			t.Fatalf("unexpected error when creating tracer: %v", err)
 		}
 		req, _ := http.NewRequest("GET", srv.URL, nil)
-		transport, _ := NewTransport(tracer, TransportErrHandler(func(_ zipkin.Span, err error, statusCode int) {
-			if want, have := tc.expectedError, statusCode; want != 0 && want != have {
-				t.Errorf("unexpected status code, want %d, have %d", want, have)
-			}
-		}))
+		transport, _ := NewTransport(
+			tracer,
+			TransportErrHandler(func(_ zipkin.Span, err error, statusCode int) {
+				if want, have := tc.expectedError, statusCode; want != 0 && want != have {
+					t.Errorf("unexpected status code, want %d, have %d", want, have)
+				}
+			}),
+		)
 
 		_, err = transport.RoundTrip(req)
 		if err != nil {

--- a/middleware/http/transport_test.go
+++ b/middleware/http/transport_test.go
@@ -1,0 +1,56 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	zipkin "github.com/openzipkin/zipkin-go"
+)
+
+func TestRoundTripErrHandling(t *testing.T) {
+	tcs := []struct {
+		actualStatusCode int
+		expectedError    int
+	}{
+		// we start on 200, if we pass 100 it will wait until timeout.
+		{
+			actualStatusCode: 200,
+		},
+		{
+			actualStatusCode: 301,
+		},
+		{
+			actualStatusCode: 403,
+			expectedError:    403,
+		},
+		{
+			actualStatusCode: 504,
+			expectedError:    504,
+		},
+	}
+
+	for _, tc := range tcs {
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.WriteHeader(tc.actualStatusCode)
+		}))
+
+		tracer, err := zipkin.NewTracer(nil)
+		if err != nil {
+			t.Fatalf("unexpected error when creating tracer: %v", err)
+		}
+		req, _ := http.NewRequest("GET", srv.URL, nil)
+		transport, _ := NewTransport(tracer, TransportErrHandler(func(_ zipkin.Span, err error, statusCode int) {
+			if want, have := tc.expectedError, statusCode; want != 0 && want != have {
+				t.Errorf("unexpected status code, want %d, have %d", want, have)
+			}
+		}))
+
+		_, err = transport.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("unexpected error in the round trip: %v", err)
+		}
+
+		srv.Close()
+	}
+}


### PR DESCRIPTION
This PR allows instrumentors to decide what to tag as error based on the error in the transport.RoundTrip and the status code (when status code is >399).

Example use case: an auth service could decide to not to mark 4xx as error.

Ping @adriancole @basvanbeek 