### PR TITLE
chore: fixes build in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,20 @@ language: go
 
 sudo: false
 
-go:
-  - 1.9.x
-  - 1.10.x
-  - 1.11.x
-  - 1.12.x
-  - tip
+matrix:
+  include:
+    - go: "1.9.x"
+    - go: "1.10.x"     
+    - go: "1.11.x"
+      env:
+        - GO111MODULE=on
+    - go: "1.12.x"
+      env:
+        - GO111MODULE=on      
+    - go: "tip"
+      env:
+        - GO111MODULE=on
+
 before_install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
This PR fixes the travis build by enabling go modules in 1.11, 1.12 and tip.

Ping @basvanbeek 