### PR TITLE
Remove Tag abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 
 .idea
+
+vendor

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Shopify/sarama v1.19.0 h1:9oksLxC6uxVPHPVYUmq6xhr1BOF/hHobWH2UzO67z1s=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
-github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -14,12 +13,10 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
@@ -51,7 +48,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJV
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
@@ -64,7 +60,6 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.20.0 h1:DlsSIrgEBuZAUFJcta2B5i/lzeHHbnfkNFAfFXLVFYQ=
 google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/middleware/grpc/shared.go
+++ b/middleware/grpc/shared.go
@@ -49,10 +49,10 @@ func handleRPC(ctx context.Context, rs stats.RPCStats) {
 				// Uppercase for consistency with Brave
 				c := strings.ToUpper(s.Code().String())
 				span.Tag("grpc.status_code", c)
-				zipkin.TagError.Set(span, c)
+				span.Tag(zipkin.TagError, c)
 			}
 		} else {
-			zipkin.TagError.Set(span, rs.Error.Error())
+			span.Tag(zipkin.TagError, rs.Error.Error())
 		}
 		span.Finish()
 	}

--- a/middleware/http/client.go
+++ b/middleware/http/client.go
@@ -108,14 +108,14 @@ func (c *Client) DoWithAppSpan(req *http.Request, name string) (res *http.Respon
 
 	appSpan := c.tracer.StartSpan(name, zipkin.Parent(parentContext))
 
-	zipkin.TagHTTPMethod.Set(appSpan, req.Method)
-	zipkin.TagHTTPPath.Set(appSpan, req.URL.Path)
+	appSpan.Tag(zipkin.TagHTTPMethod, req.Method)
+	appSpan.Tag(zipkin.TagHTTPPath, req.URL.Path)
 
 	res, err = c.Client.Do(
 		req.WithContext(zipkin.NewContext(req.Context(), appSpan)),
 	)
 	if err != nil {
-		zipkin.TagError.Set(appSpan, err.Error())
+		appSpan.Tag(zipkin.TagError, err.Error())
 		appSpan.Finish()
 		return
 	}
@@ -125,13 +125,13 @@ func (c *Client) DoWithAppSpan(req *http.Request, name string) (res *http.Respon
 	}
 
 	if res.ContentLength > 0 {
-		zipkin.TagHTTPResponseSize.Set(appSpan, strconv.FormatInt(res.ContentLength, 10))
+		appSpan.Tag(zipkin.TagHTTPResponseSize, strconv.FormatInt(res.ContentLength, 10))
 	}
 	if res.StatusCode < 200 || res.StatusCode > 299 {
 		statusCode := strconv.FormatInt(int64(res.StatusCode), 10)
-		zipkin.TagHTTPStatusCode.Set(appSpan, statusCode)
+		appSpan.Tag(zipkin.TagHTTPStatusCode, statusCode)
 		if res.StatusCode > 399 {
-			zipkin.TagError.Set(appSpan, statusCode)
+			appSpan.Tag(zipkin.TagError, statusCode)
 		}
 	}
 

--- a/middleware/http/server.go
+++ b/middleware/http/server.go
@@ -129,10 +129,10 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := zipkin.NewContext(r.Context(), sp)
 
 	// tag typical HTTP request items
-	zipkin.TagHTTPMethod.Set(sp, r.Method)
-	zipkin.TagHTTPPath.Set(sp, r.URL.Path)
+	sp.Tag(zipkin.TagHTTPMethod, r.Method)
+	sp.Tag(zipkin.TagHTTPPath, r.URL.Path)
 	if r.ContentLength > 0 {
-		zipkin.TagHTTPRequestSize.Set(sp, strconv.FormatInt(r.ContentLength, 10))
+		sp.Tag(zipkin.TagHTTPRequestSize, strconv.FormatInt(r.ContentLength, 10))
 	}
 
 	// create http.ResponseWriter interceptor for tracking response size and
@@ -146,9 +146,9 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if code > 399 {
 			h.errHandler(sp, nil, code)
 		}
-		zipkin.TagHTTPStatusCode.Set(sp, sCode)
+		sp.Tag(zipkin.TagHTTPStatusCode, sCode)
 		if h.tagResponseSize && atomic.LoadUint64(&ri.size) > 0 {
-			zipkin.TagHTTPResponseSize.Set(sp, ri.getResponseSize())
+			sp.Tag(zipkin.TagHTTPResponseSize, ri.getResponseSize())
 		}
 		sp.Finish()
 	}()

--- a/tags.go
+++ b/tags.go
@@ -14,24 +14,16 @@
 
 package zipkin
 
-// Tag holds available types
-type Tag string
-
 // Common Tag values
 const (
-	TagHTTPMethod       Tag = "http.method"
-	TagHTTPPath         Tag = "http.path"
-	TagHTTPUrl          Tag = "http.url"
-	TagHTTPRoute        Tag = "http.route"
-	TagHTTPStatusCode   Tag = "http.status_code"
-	TagHTTPRequestSize  Tag = "http.request.size"
-	TagHTTPResponseSize Tag = "http.response.size"
-	TagGRPCStatusCode   Tag = "grpc.status_code"
-	TagSQLQuery         Tag = "sql.query"
-	TagError            Tag = "error"
+	TagHTTPMethod       = "http.method"
+	TagHTTPPath         = "http.path"
+	TagHTTPUrl          = "http.url"
+	TagHTTPRoute        = "http.route"
+	TagHTTPStatusCode   = "http.status_code"
+	TagHTTPRequestSize  = "http.request.size"
+	TagHTTPResponseSize = "http.response.size"
+	TagGRPCStatusCode   = "grpc.status_code"
+	TagSQLQuery         = "sql.query"
+	TagError            = "error"
 )
-
-// Set a standard Tag with a payload on provided Span.
-func (t Tag) Set(s Span, value string) {
-	s.Tag(string(t), value)
-}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -486,7 +486,7 @@ func TestTagOverwriteRules(t *testing.T) {
 		t.Errorf("Tag want %s=%s, have %s=%s", k1, want, k1, have)
 	}
 
-	TagError.Set(s, v1Last)
+	s.Tag(TagError, v1Last)
 
 	if want, have := v1First, s.(*spanImpl).Tags[k2]; want != have {
 		t.Errorf("Tag want %s=%s, have %s=%s", k1, want, k1, have)


### PR DESCRIPTION
Just my opinionated PR about abstraction, I felt that  Tag#Set method is pretty weird since it try to set another object property, which is not really necessary because `Span#Tag` method is clear enough for most use.