### PR TITLE
Adding FinishedWithDuration to Span interface

### DIFF
--- a/noop.go
+++ b/noop.go
@@ -36,4 +36,6 @@ func (*noopSpan) Tag(string, string) {}
 
 func (*noopSpan) Finish() {}
 
+func (*noopSpan) FinishedWithDuration(duration time.Duration) {}
+
 func (*noopSpan) Flush() {}

--- a/span.go
+++ b/span.go
@@ -45,6 +45,12 @@ type Span interface {
 	// span.Flush).
 	Finish()
 
+	// Finish the Span with duration and send to Reporter. If DelaySend option was used at
+	// Span creation time, FinishedWithDuration will not send the Span to the Reporter. It then
+	// becomes the user's responsibility to get the Span reported (by using
+	// span.Flush).
+	FinishedWithDuration(duration time.Duration)
+
 	// Flush the Span to the Reporter (regardless of being finished or not).
 	// This can be used if the DelaySend SpanOption was set or when dealing with
 	// one-way RPC tracing where duration might not be measured.


### PR DESCRIPTION
To export func FinishedWithDuration(duration time.Duration) 

add FinishedWithDuration(duration time.Duration) to span.go and an empty impl in noop.go