### PR TITLE
reporter timeout not working #147

### DIFF
--- a/reporter/http/http.go
+++ b/reporter/http/http.go
@@ -19,14 +19,14 @@ package http
 
 import (
 	"bytes"
+	"github.com/openzipkin/zipkin-go/model"
+	"github.com/openzipkin/zipkin-go/reporter"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"sync"
 	"time"
-	"math"
-	"github.com/openzipkin/zipkin-go/model"
-	"github.com/openzipkin/zipkin-go/reporter"
 )
 
 // defaults
@@ -61,9 +61,7 @@ type httpReporter struct {
 
 // Send implements reporter
 func (r *httpReporter) Send(s model.SpanModel) {
-	if r.retryCounter > 0 {
-		r.spanC <- &s
-	}
+	r.spanC <- &s
 }
 
 // Close implements reporter


### PR DESCRIPTION
Hi, this pull request is related to feature request(#147), I have tried to add timeout feature by adding maximum reentry. if server is down, then reporter tries to reach server for max reentry set by user, if it exceeds the limit, then all spans in batch will be dropped and reporter will not try to reach server any more.  I am very new to golang and this is my first contribution to opensource project, please forgive me if there are any bad code practice and any feedback is appreciated.