### PR TITLE
Adding support for Json scientific notation on timestamp

### DIFF
--- a/model/span.go
+++ b/model/span.go
@@ -140,7 +140,7 @@ func (s *SpanModel) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-	s.Duration = time.Duration(d * 1e3) * time.Nanosecond
+	s.Duration = time.Duration(d*1e3) * time.Nanosecond
 
 	if s.LocalEndpoint.Empty() {
 		s.LocalEndpoint = nil

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -285,7 +285,7 @@ func TestSpanUnmarshalScientificNotationTimestamp(t *testing.T) {
 		}
 
 		expected := 54500 * time.Microsecond
-		if span.Duration !=  expected {
+		if span.Duration != expected {
 			t.Errorf("Invalid unmarshaled duration, want: %v, have: %+v", span.Duration, expected)
 		}
 	})

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -268,7 +268,7 @@ func TestSpanUnmarshalScientificNotationTimestamp(t *testing.T) {
 		}
 
 		expected := time.Unix(1582662767, 960310000).UnixNano()
-		if span.Timestamp.UnixNano() !=  expected{
+		if span.Timestamp.UnixNano() != expected {
 			t.Errorf("Invalid unmarshaled timestamp, want: %v, have: %+v", expected, span.Timestamp.UnixNano())
 		}
 	})

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -254,3 +254,39 @@ func TestSpanNegativeTimestamp(t *testing.T) {
 	}
 
 }
+
+func TestSpanUnmarshalScientificNotationTimestamp(t *testing.T) {
+	t.Run("Validate span timestamp", func(t *testing.T) {
+		var (
+			err  error
+			span SpanModel
+			b    = []byte(`{"traceId":"1", "id":"1", "timestamp":1.58266276796031e+15}`)
+		)
+
+		if err = json.Unmarshal(b, &span); err != nil {
+			t.Errorf("Unmarshal should have worked without error, have: %+v", span)
+		}
+
+		expected := time.Unix(1582662767, 960310000).UnixNano()
+		if span.Timestamp.UnixNano() !=  expected{
+			t.Errorf("Invalid unmarshaled timestamp, want: %v, have: %+v", expected, span.Timestamp.UnixNano())
+		}
+	})
+
+	t.Run("Validate span duration", func(t *testing.T) {
+		var (
+			err  error
+			span SpanModel
+			b    = []byte(`{"traceId":"1", "id":"1", "duration":5.45e+4}`)
+		)
+
+		if err = json.Unmarshal(b, &span); err != nil {
+			t.Errorf("Unmarshal should have worked without error, have: %+v", span)
+		}
+
+		expected := 54500 * time.Microsecond
+		if span.Duration !=  expected {
+			t.Errorf("Invalid unmarshaled duration, want: %v, have: %+v", span.Duration, expected)
+		}
+	})
+}


### PR DESCRIPTION
Adding support for scientific notation on timestamp and Duration. 

See Envoy original issue: https://github.com/envoyproxy/envoy/issues/9341

Please let me know if anyone have concerns. Thanks!