### PR TITLE
feat(json-format): lowercase span name and service name as per swagger definition

### DIFF
--- a/model/endpoint.go
+++ b/model/endpoint.go
@@ -14,14 +14,33 @@
 
 package model
 
-import "net"
+import (
+	"encoding/json"
+	"net"
+	"strings"
+)
 
 // Endpoint holds the network context of a node in the service graph.
 type Endpoint struct {
-	ServiceName string `json:"serviceName,omitempty"`
-	IPv4        net.IP `json:"ipv4,omitempty"`
-	IPv6        net.IP `json:"ipv6,omitempty"`
-	Port        uint16 `json:"port,omitempty"`
+	ServiceName string
+	IPv4        net.IP
+	IPv6        net.IP
+	Port        uint16
+}
+
+// MarshalJSON exports our Endpoint into the correct format for the Zipkin V2 API.
+func (e Endpoint) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		ServiceName string `json:"serviceName,omitempty"`
+		IPv4        net.IP `json:"ipv4,omitempty"`
+		IPv6        net.IP `json:"ipv6,omitempty"`
+		Port        uint16 `json:"port,omitempty"`
+	}{
+		strings.ToLower(e.ServiceName),
+		e.IPv4,
+		e.IPv6,
+		e.Port,
+	})
 }
 
 // Empty returns if all Endpoint properties are empty / unspecified.

--- a/model/span.go
+++ b/model/span.go
@@ -17,6 +17,7 @@ package model
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -86,6 +87,8 @@ func (s SpanModel) MarshalJSON() ([]byte, error) {
 		// will be naturally rounded. See TestSpanDurationRounding in span_test.go
 		s.Duration += 500 * time.Nanosecond
 	}
+
+	s.Name = strings.ToLower(s.Name)
 
 	if s.LocalEndpoint.Empty() {
 		s.LocalEndpoint = nil

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -83,6 +84,9 @@ func TestSpanJSON(t *testing.T) {
 	for idx := range span1.Annotations {
 		span1.Annotations[idx].Timestamp = span1.Annotations[idx].Timestamp.Round(time.Microsecond)
 	}
+
+	span1.Name = strings.ToLower(span1.Name)
+	span1.LocalEndpoint.ServiceName = strings.ToLower(span1.LocalEndpoint.ServiceName)
 
 	if !reflect.DeepEqual(span1, span2) {
 		t.Errorf("want SpanModel: %+v, have: %+v", span1, span2)


### PR DESCRIPTION
I just discovered the JSON V2 API expected the service names and the span names to be lower case. This PR address that.

![image](https://user-images.githubusercontent.com/3075074/89295813-ceec8400-d661-11ea-91cc-fd30d55b3a2f.png)

![image](https://user-images.githubusercontent.com/3075074/89295833-d90e8280-d661-11ea-83c3-eb4a81b993f5.png)

https://zipkin.io/zipkin-api/\#/default/post_spans.

Ping @basvanbeek 