### PR TITLE
Don't include the http.status_code when 2xx in server.

### DIFF
--- a/middleware/http/server.go
+++ b/middleware/http/server.go
@@ -145,10 +145,12 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		code := ri.getStatusCode()
 		sCode := strconv.Itoa(code)
-		if code > 399 {
-			h.errHandler(sp, nil, code)
+		if code < 200 || code > 299 {
+			zipkin.TagHTTPStatusCode.Set(sp, sCode)
+			if code > 399 {
+				h.errHandler(sp, nil, code)
+			}
 		}
-		zipkin.TagHTTPStatusCode.Set(sp, sCode)
 		if h.tagResponseSize && atomic.LoadUint64(&ri.size) > 0 {
 			zipkin.TagHTTPResponseSize.Set(sp, ri.getResponseSize())
 		}

--- a/middleware/http/server_test.go
+++ b/middleware/http/server_test.go
@@ -179,6 +179,7 @@ func TestHTTPDefaultSpanName(t *testing.T) {
 		httpRecorder = httptest.NewRecorder()
 		requestBuf   = bytes.NewBufferString("incoming data")
 		methodType   = "POST"
+		code         = ""
 	)
 
 	request, err := http.NewRequest(methodType, "/test", requestBuf)
@@ -202,6 +203,10 @@ func TestHTTPDefaultSpanName(t *testing.T) {
 
 	if want, have := methodType, span.Name; want != have {
 		t.Errorf("Expected span name %s, got %s", want, have)
+	}
+
+	if want, have := code, span.Tags["http.status_code"]; want != have {
+		t.Errorf("Expected span status code %s, got %s", want, have)
 	}
 }
 


### PR DESCRIPTION
for [https://github.com/openzipkin/zipkin-go/issues/162](https://github.com/openzipkin/zipkin-go/issues/162)