### PR TITLE
Remove deprecated sudo setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ dist: trusty
 services:
   - rabbitmq
 
-sudo: false
-
 matrix:
   include:
     - go: "1.9.x"


### PR DESCRIPTION
Travis are now recommending removing the sudo tag. see: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration