### PR TITLE
feat: adds support for isNoop check on spans.

### DIFF
--- a/middleware/grpc/server.go
+++ b/middleware/grpc/server.go
@@ -83,7 +83,7 @@ func (s *serverHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) conte
 
 	span := s.tracer.StartSpan(name, zipkin.Kind(model.Server), zipkin.Parent(sc), zipkin.RemoteEndpoint(remoteEndpointFromContext(ctx, "")))
 
-	if !span.IsNoop() {
+	if !zipkin.IsNoop(span) {
 		for k, v := range s.defaultTags {
 			span.Tag(k, v)
 		}

--- a/middleware/grpc/server.go
+++ b/middleware/grpc/server.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The OpenZipkin Authors
+// Copyright 2020 The OpenZipkin Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/middleware/grpc/server.go
+++ b/middleware/grpc/server.go
@@ -83,8 +83,10 @@ func (s *serverHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) conte
 
 	span := s.tracer.StartSpan(name, zipkin.Kind(model.Server), zipkin.Parent(sc), zipkin.RemoteEndpoint(remoteEndpointFromContext(ctx, "")))
 
-	for k, v := range s.defaultTags {
-		span.Tag(k, v)
+	if !span.IsNoop() {
+		for k, v := range s.defaultTags {
+			span.Tag(k, v)
+		}
 	}
 
 	return zipkin.NewContext(ctx, span)

--- a/middleware/grpc/shared.go
+++ b/middleware/grpc/shared.go
@@ -39,7 +39,7 @@ func spanName(rti *stats.RPCTagInfo) string {
 
 func handleRPC(ctx context.Context, rs stats.RPCStats) {
 	span := zipkin.SpanFromContext(ctx)
-	if span.IsNoop() {
+	if zipkin.IsNoop(span) {
 		return
 	}
 

--- a/middleware/grpc/shared.go
+++ b/middleware/grpc/shared.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The OpenZipkin Authors
+// Copyright 2020 The OpenZipkin Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/middleware/grpc/shared.go
+++ b/middleware/grpc/shared.go
@@ -39,6 +39,9 @@ func spanName(rti *stats.RPCTagInfo) string {
 
 func handleRPC(ctx context.Context, rs stats.RPCStats) {
 	span := zipkin.SpanFromContext(ctx)
+	if span.IsNoop() {
+		return
+	}
 
 	switch rs := rs.(type) {
 	case *stats.End:

--- a/middleware/http/server.go
+++ b/middleware/http/server.go
@@ -122,7 +122,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// add our span to context
 	ctx := zipkin.NewContext(r.Context(), sp)
 
-	if sp.IsNoop() {
+	if zipkin.IsNoop(sp) {
 		// While the span is not being recorded, we still want to propagate the context.
 		h.next.ServeHTTP(w, r.WithContext(ctx))
 		return

--- a/middleware/http/server.go
+++ b/middleware/http/server.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The OpenZipkin Authors
+// Copyright 2020 The OpenZipkin Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -123,6 +123,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := zipkin.NewContext(r.Context(), sp)
 
 	if sp.IsNoop() {
+		// While the span is not being recorded, we still want to propagate the context.
 		h.next.ServeHTTP(w, r.WithContext(ctx))
 		return
 	}

--- a/middleware/http/transport.go
+++ b/middleware/http/transport.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The OpenZipkin Authors
+// Copyright 2020 The OpenZipkin Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -155,6 +155,7 @@ func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 	)
 
 	if sp.IsNoop() {
+		// While the span is not being recorded, we still want to propagate the context.
 		_ = b3.InjectHTTP(req)(sp.Context())
 		return t.rt.RoundTrip(req)
 	}

--- a/middleware/http/transport.go
+++ b/middleware/http/transport.go
@@ -154,6 +154,11 @@ func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 		req.Context(), req.URL.Scheme+"/"+req.Method, zipkin.Kind(model.Client), zipkin.RemoteEndpoint(t.remoteEndpoint),
 	)
 
+	if sp.IsNoop() {
+		_ = b3.InjectHTTP(req)(sp.Context())
+		return t.rt.RoundTrip(req)
+	}
+
 	for k, v := range t.defaultTags {
 		sp.Tag(k, v)
 	}

--- a/middleware/http/transport.go
+++ b/middleware/http/transport.go
@@ -154,7 +154,7 @@ func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 		req.Context(), req.URL.Scheme+"/"+req.Method, zipkin.Kind(model.Client), zipkin.RemoteEndpoint(t.remoteEndpoint),
 	)
 
-	if sp.IsNoop() {
+	if zipkin.IsNoop(sp) {
 		// While the span is not being recorded, we still want to propagate the context.
 		_ = b3.InjectHTTP(req)(sp.Context())
 		return t.rt.RoundTrip(req)

--- a/noop.go
+++ b/noop.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The OpenZipkin Authors
+// Copyright 2020 The OpenZipkin Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/noop.go
+++ b/noop.go
@@ -40,4 +40,9 @@ func (*noopSpan) FinishedWithDuration(duration time.Duration) {}
 
 func (*noopSpan) Flush() {}
 
-func (*noopSpan) IsNoop() bool { return true }
+// IsNoop tells whether the span is noop or not. Usually used to avoid resource misusage
+// when customizing a span as data won't be recorded
+func IsNoop(s Span) bool {
+	_, ok := s.(*noopSpan)
+	return ok
+}

--- a/noop.go
+++ b/noop.go
@@ -39,3 +39,5 @@ func (*noopSpan) Finish() {}
 func (*noopSpan) FinishedWithDuration(duration time.Duration) {}
 
 func (*noopSpan) Flush() {}
+
+func (*noopSpan) IsNoop() bool { return true }

--- a/span.go
+++ b/span.go
@@ -55,4 +55,8 @@ type Span interface {
 	// This can be used if the DelaySend SpanOption was set or when dealing with
 	// one-way RPC tracing where duration might not be measured.
 	Flush()
+
+	// IsNoop tells whether the span is noop or not. Usually used to avoid resource misusage
+	// when customizing a span
+	IsNoop() bool
 }

--- a/span.go
+++ b/span.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The OpenZipkin Authors
+// Copyright 2020 The OpenZipkin Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,6 +57,6 @@ type Span interface {
 	Flush()
 
 	// IsNoop tells whether the span is noop or not. Usually used to avoid resource misusage
-	// when customizing a span
+	// when customizing a span as data won't be recorded
 	IsNoop() bool
 }

--- a/span.go
+++ b/span.go
@@ -55,8 +55,4 @@ type Span interface {
 	// This can be used if the DelaySend SpanOption was set or when dealing with
 	// one-way RPC tracing where duration might not be measured.
 	Flush()
-
-	// IsNoop tells whether the span is noop or not. Usually used to avoid resource misusage
-	// when customizing a span as data won't be recorded
-	IsNoop() bool
 }

--- a/span_implementation.go
+++ b/span_implementation.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The OpenZipkin Authors
+// Copyright 2020 The OpenZipkin Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/span_implementation.go
+++ b/span_implementation.go
@@ -99,7 +99,3 @@ func (s *spanImpl) Flush() {
 		s.tracer.reporter.Send(s.SpanModel)
 	}
 }
-
-func (s *spanImpl) IsNoop() bool {
-	return false
-}

--- a/span_implementation.go
+++ b/span_implementation.go
@@ -99,3 +99,7 @@ func (s *spanImpl) Flush() {
 		s.tracer.reporter.Send(s.SpanModel)
 	}
 }
+
+func (s *spanImpl) IsNoop() bool {
+	return false
+}


### PR DESCRIPTION
Span.IsNoop is specially usefull to avoid expensive operations when the tags or logs are not being recorded e.g. if you are about to read the body and process it to obtain certain tags, the check would save that computation as no changes will take effect.

References:
- https://github.com/openzipkin/brave/blob/4569d5d98adf394fffc37fb048d6f66be960e094/instrumentation/http/src/main/java/brave/http/HttpHandler.java#L37
- https://github.com/openzipkin/zipkin-php/blob/master/src/Zipkin/Instrumentation/Http/Client/Psr18/Client.php#L69

Ping @adriancole @basvanbeek 