### PR TITLE
Set Go support policy to latest-2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
   "CI":
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
+      matrix:  # Use versions consistent with zipkin-go's Go support policy.
         os: [macos-latest, windows-latest, ubuntu-latest]
-        go: ["1.20"]
+        go: ["1.22"]  # Current Go version
         include:
           - os: ubuntu-latest
-            go: "1.18"
+            go: "1.21"
           - os: ubuntu-latest
-            go: "1.19"
+            go: "1.20"  # Floor Go version of zipkin-go (current - 2)
     steps:
       # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
       - name: Check out code

--- a/README.md
+++ b/README.md
@@ -112,5 +112,17 @@ Producer digesting JSON V2 Spans. The reporter uses the
 [Sarama async producer](https://pkg.go.dev/github.com/IBM/sarama#AsyncProducer)
 underneath.
 
-## usage and examples
+## Usage and Examples
 [HTTP Server Example](examples/httpserver_test.go)
+
+## Go Support Policy
+
+zipkin-go follows the same version policy as Go's [Release Policy](https://go.dev/doc/devel/release):
+two versions. zipkin-go will ensure these versions work and bugs are valid if
+there's an issue with a current Go version.
+
+Additionally, zipkin-go intentionally delays usage of language or standard
+library features one additional version. For example, when Go 1.29 is released,
+zipkin-go can use language features or standard libraries added in 1.27. This
+is a convenience for embedders who have a slower version policy than Go.
+However, only supported Go versions may be used to raise support issues.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openzipkin/zipkin-go
 
-go 1.18
+go 1.20
 
 require (
 	github.com/IBM/sarama v1.40.1


### PR DESCRIPTION
Before updating deps, we should revisit the go support policy I think. That way the next release is coherent across the board. This is the same templating as wazero, which had to deal with some projects that lagged behind Go.