### PR TITLE
fix boundary sampler so it is true to given rate

### DIFF
--- a/sample.go
+++ b/sample.go
@@ -61,11 +61,11 @@ func NewBoundarySampler(rate float64, salt int64) (Sampler, error) {
 	}
 
 	var (
-		boundary = int64(rate * 10000)
+		boundary = uint64(rate * (1 << 63))
 		usalt    = uint64(salt)
 	)
 	return func(id uint64) bool {
-		return int64(math.Abs(float64(id^usalt)))%10000 < boundary
+		return ((id ^ usalt) >> 1) < boundary
 	}, nil
 }
 

--- a/sample.go
+++ b/sample.go
@@ -67,6 +67,8 @@ func NewBoundarySampler(rate float64, salt int64) (Sampler, error) {
 		usalt    = uint64(salt)
 	)
 	return func(id uint64) bool {
+		// XOR with salt provides deterministic randomization
+		//   right shift ensures uniform distribution across [0, 2^63)
 		return ((id ^ usalt) >> 1) < boundary
 	}, nil
 }

--- a/sample.go
+++ b/sample.go
@@ -61,6 +61,8 @@ func NewBoundarySampler(rate float64, salt int64) (Sampler, error) {
 	}
 
 	var (
+		// convert rate into a proportional boundary where values below it are sampled
+		//   (e.g., 1% rate ≈ first 1% of space)
 		boundary = uint64(rate * (1 << 63))
 		usalt    = uint64(salt)
 	)


### PR DESCRIPTION
Fixes #225 

Solution works accurately on both amd64 and arm64 architectures. 

Adds test to ensure number of sampling decisions falls within a given range.

Avoid float to int conversion which is platform dependent for high values (such as trace IDs)